### PR TITLE
SOE-3320: removed soe-default from postcard

### DIFF
--- a/stanford_bean_types.strongarm.inc
+++ b/stanford_bean_types.strongarm.inc
@@ -136,7 +136,7 @@ function stanford_bean_types_strongarm() {
         'custom_settings' => TRUE,
       ),
       'stanford_soe_default' => array(
-        'custom_settings' => TRUE,
+        'custom_settings' => FALSE,
       ),
       'header_370x170' => array(
         'custom_settings' => FALSE,


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This removes the _soe-default_ view mode from the Postcard bean type

# Needed By (Date)
- Sprint end

# Criticality
- Client is eagerly awaiting this.
- Housekeeping
- Fixes broken stuff
- Fixed on prod, need to put into code.

# Steps to Test
Clone this repo into sites/default/modules
`git clone git@github.com:SU-SOE/stanford_bean_types.git`

Check out this branch
`git checkout 7.x-2.x-dev-soe-3320-remove-postcard-soe-default`

Help Drupal find the repo
`drush rr`

Verify you see the change in the new branch:
`drush fd stanford_bean_types`
```Component: variable
            'visible' => TRUE,
            'weight' => -5,
>         ),
>         'stanford_soe_default' => array(
>           'custom_settings' => TRUE,
          ),
        ),
```

Revert the feature
`drush fr stanford_bean_types`

Create a new Postcard bean and verify that the _soe-default_ view mode no longer exists.

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-3320

## Related PRs

## More Information

## Folks to notify
@annawatt
@kerri-augenstein


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)