### PR TITLE
Featured Video Styling SOE-3561 and SOE-3695

### DIFF
--- a/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
+++ b/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
@@ -675,7 +675,7 @@ div[class*="featured"] .entity-paragraphs-item {
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise {
-        margin: 10px 0 10px;
+        margin: 10px 0;
         padding: 0.8em 1.2em 0.9em; } }
   /* line 807, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {

--- a/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
+++ b/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
@@ -157,33 +157,44 @@ div[class*="featured"] .entity-paragraphs-item {
     max-height: 150px;
     min-height: 100px; } }
 
-/* line 207, ../scss/stanford_bean_types_featured.scss */
+@media (max-width: 979px) {
+  /* line 206, ../scss/stanford_bean_types_featured.scss */
+  .paragraphs-item-p-featured.has-video > .content .field-name-field-p-featured-image img {
+    max-height: 400px;
+    min-height: 200px; } }
+@media (max-width: 767px) {
+  /* line 206, ../scss/stanford_bean_types_featured.scss */
+  .paragraphs-item-p-featured.has-video > .content .field-name-field-p-featured-image img {
+    max-height: 200px;
+    min-height: 100px; } }
+
+/* line 220, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured {
   margin-bottom: 0; }
-  /* line 210, ../scss/stanford_bean_types_featured.scss */
+  /* line 223, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured a.play-video {
     color: #ffffff;
     display: block;
     font-size: 0;
     z-index: 3; }
-  /* line 217, ../scss/stanford_bean_types_featured.scss */
+  /* line 230, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured .field-name-field-p-featured-image {
     background: #001933;
     position: relative;
     z-index: 2; }
-    /* line 222, ../scss/stanford_bean_types_featured.scss */
+    /* line 235, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured .field-name-field-p-featured-image img {
       height: auto;
       opacity: .3;
       width: 100%; }
-  /* line 229, ../scss/stanford_bean_types_featured.scss */
+  /* line 242, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured .field-name-field-p-featured-video {
     height: auto;
     position: absolute;
     width: 100%;
     top: -20px;
     z-index: 1; }
-  /* line 237, ../scss/stanford_bean_types_featured.scss */
+  /* line 250, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured div.group-overlay-text {
     background-color: transparent;
     color: #fff;
@@ -197,28 +208,28 @@ div[class*="featured"] .entity-paragraphs-item {
     width: 100%;
     z-index: 2; }
     @media (max-width: 979px) {
-      /* line 237, ../scss/stanford_bean_types_featured.scss */
+      /* line 250, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text {
         position: relative;
         width: 100%; } }
-    /* line 256, ../scss/stanford_bean_types_featured.scss */
+    /* line 269, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text > div,
     .paragraphs-item-p-featured div.group-overlay-text > h2 {
       display: table-cell;
       float: left;
       vertical-align: middle;
       width: 100%; }
-    /* line 264, ../scss/stanford_bean_types_featured.scss */
+    /* line 277, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 {
       color: #ffffff;
       font-size: 32px;
       line-height: 1.1em;
       margin: 10px 0 0; }
       @media (max-width: 580px) {
-        /* line 264, ../scss/stanford_bean_types_featured.scss */
+        /* line 277, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 {
           font-size: 24px; } }
-      /* line 275, ../scss/stanford_bean_types_featured.scss */
+      /* line 288, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 a {
         background-color: transparent;
         box-shadow: none;
@@ -227,68 +238,68 @@ div[class*="featured"] .entity-paragraphs-item {
         padding: 0;
         -webkit-text-decoration-color: #00ece9;
         text-decoration-color: #00ece9; }
-        /* line 284, ../scss/stanford_bean_types_featured.scss */
+        /* line 297, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 a:after {
           content: ''; }
-        /* line 288, ../scss/stanford_bean_types_featured.scss */
+        /* line 301, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 a:hover {
           -webkit-text-decoration-color: #ffffff;
           text-decoration-color: #ffffff; }
-    /* line 295, ../scss/stanford_bean_types_featured.scss */
+    /* line 308, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
       font-size: 20px;
       font-weight: 600;
       letter-spacing: 0; }
-      /* line 300, ../scss/stanford_bean_types_featured.scss */
+      /* line 313, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead a {
         color: #ffbd54;
         text-decoration: none;
         -webkit-text-decoration-color: #ffbd54;
         text-decoration-color: #ffbd54; }
-        /* line 306, ../scss/stanford_bean_types_featured.scss */
+        /* line 319, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead a:hover {
           color: #ffffff;
           text-decoration: underline;
           -webkit-text-decoration-color: #ffffff;
           text-decoration-color: #ffffff; }
-    /* line 315, ../scss/stanford_bean_types_featured.scss */
+    /* line 328, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
       font-size: 18px;
       line-height: 1.2em;
       margin: 20px 0 0; }
       @media (max-width: 767px) {
-        /* line 315, ../scss/stanford_bean_types_featured.scss */
+        /* line 328, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
           margin: 20px 0; } }
-      /* line 325, ../scss/stanford_bean_types_featured.scss */
+      /* line 338, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
         line-height: 1.3em;
         margin: 0 10%; }
-    /* line 331, ../scss/stanford_bean_types_featured.scss */
+    /* line 344, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link {
       margin-top: 30px; }
       @media (max-width: 979px) {
-        /* line 331, ../scss/stanford_bean_types_featured.scss */
+        /* line 344, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link {
           margin-bottom: 30px; } }
-      /* line 339, ../scss/stanford_bean_types_featured.scss */
+      /* line 352, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a {
         color: #ffffff;
         text-decoration: underline;
         -webkit-text-decoration-color: #ff525c;
         text-decoration-color: #ff525c; }
-        /* line 345, ../scss/stanford_bean_types_featured.scss */
+        /* line 358, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a:hover {
           -webkit-text-decoration-color: #ffffff;
           text-decoration-color: #ffffff; }
-        /* line 350, ../scss/stanford_bean_types_featured.scss */
+        /* line 363, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a:after {
           content: ' ›'; }
         @media (max-width: 979px) {
-          /* line 339, ../scss/stanford_bean_types_featured.scss */
+          /* line 352, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a {
             color: #333333; } }
-    /* line 361, ../scss/stanford_bean_types_featured.scss */
+    /* line 374, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
     .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
     .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise {
@@ -306,18 +317,18 @@ div[class*="featured"] .entity-paragraphs-item {
       padding: 0.8em 1.2em 0.9em;
       text-align: center;
       text-decoration: none; }
-      /* line 379, ../scss/stanford_bean_types_featured.scss */
+      /* line 392, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text a.btn-orange:after,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-pink:after,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise:after {
         content: ''; }
-      /* line 383, ../scss/stanford_bean_types_featured.scss */
+      /* line 396, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text a.btn-orange:hover,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-pink:hover,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise:hover {
         background: #333333;
         color: #fff; }
-    /* line 389, ../scss/stanford_bean_types_featured.scss */
+    /* line 402, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text a.btn {
       -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
       -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
@@ -332,155 +343,158 @@ div[class*="featured"] .entity-paragraphs-item {
       padding: 0.8em 1.2em 0.9em;
       text-align: center;
       text-decoration: none; }
-      /* line 404, ../scss/stanford_bean_types_featured.scss */
+      /* line 417, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text a.btn:after {
         content: ''; }
 
-/* line 414, ../scss/stanford_bean_types_featured.scss */
+/* line 427, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
   font-size: 22px; }
   @media (max-width: 979px) {
-    /* line 414, ../scss/stanford_bean_types_featured.scss */
+    /* line 427, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
       font-size: 18px; } }
 
-/* line 428, ../scss/stanford_bean_types_featured.scss */
+/* line 441, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-image .field-name-field-p-featured-image {
   width: 100%; }
-/* line 432, ../scss/stanford_bean_types_featured.scss */
+/* line 445, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-image .group-overlay-text {
   margin-top: 1%;
   position: relative;
   width: 100%; }
-  /* line 437, ../scss/stanford_bean_types_featured.scss */
+  /* line 450, ../scss/stanford_bean_types_featured.scss */
   .span6 .paragraphs-item-p-featured.has-image .group-overlay-text .field-name-field-p-featured-superhead {
     padding-top: 40px; }
-/* line 444, ../scss/stanford_bean_types_featured.scss */
+/* line 457, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
   width: 100%; }
-/* line 448, ../scss/stanford_bean_types_featured.scss */
+/* line 461, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-video .group-overlay-text {
   margin-top: 1%;
   position: relative;
   width: 100%; }
-  /* line 453, ../scss/stanford_bean_types_featured.scss */
+  /* line 466, ../scss/stanford_bean_types_featured.scss */
   .span6 .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead {
     padding-top: 40px; }
 
-/* line 461, ../scss/stanford_bean_types_featured.scss */
+/* line 474, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured.has-image div.group-overlay-text {
   background: transparent;
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%); }
-  /* line 468, ../scss/stanford_bean_types_featured.scss */
+  /* line 481, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead {
     padding-top: 20px; }
-    /* line 471, ../scss/stanford_bean_types_featured.scss */
+    /* line 484, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a {
       color: #ffbd54;
       text-decoration: none; }
-      /* line 475, ../scss/stanford_bean_types_featured.scss */
+      /* line 488, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a:hover {
         color: #ffffff;
         text-decoration: underline; }
   @media (max-width: 979px) {
-    /* line 461, ../scss/stanford_bean_types_featured.scss */
+    /* line 474, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image div.group-overlay-text {
       left: initial;
       position: relative;
       transform: none; }
-      /* line 488, ../scss/stanford_bean_types_featured.scss */
+      /* line 501, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead {
         padding-top: 20px; }
-        /* line 491, ../scss/stanford_bean_types_featured.scss */
+        /* line 504, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a {
           color: #b1040e;
           text-decoration: none; }
-          /* line 495, ../scss/stanford_bean_types_featured.scss */
+          /* line 508, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a:hover {
             color: #333333;
             text-decoration: underline;
             -webkit-text-decoration-color: #333333;
             text-decoration-color: #333333; }
-      /* line 504, ../scss/stanford_bean_types_featured.scss */
+      /* line 517, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image div.group-overlay-text .group-headline-h2,
       .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-description {
         color: #333333; }
-        /* line 508, ../scss/stanford_bean_types_featured.scss */
+        /* line 521, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-image div.group-overlay-text .group-headline-h2 a,
         .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-description a {
           color: #333333; } }
 
-/* line 517, ../scss/stanford_bean_types_featured.scss */
+/* line 530, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured.has-image.has-video .group-overlay-text {
   background: transparent;
   left: 0;
   position: absolute;
   transform: none; }
-  /* line 524, ../scss/stanford_bean_types_featured.scss */
-  .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a {
-    text-decoration: underline;
-    -webkit-text-decoration-color: #ffbd54;
-    text-decoration-color: #ffbd54; }
-    /* line 529, ../scss/stanford_bean_types_featured.scss */
-    .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a:hover {
-      color: #333333;
-      -webkit-text-decoration-color: #ffffff;
-      text-decoration-color: #ffffff; }
+  /* line 536, ../scss/stanford_bean_types_featured.scss */
+  .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead {
+    padding-top: 0; }
+    /* line 539, ../scss/stanford_bean_types_featured.scss */
+    .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a {
+      text-decoration: underline;
+      -webkit-text-decoration-color: #ffbd54;
+      text-decoration-color: #ffbd54; }
+      /* line 544, ../scss/stanford_bean_types_featured.scss */
+      .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a:hover {
+        color: #333333;
+        -webkit-text-decoration-color: #ffffff;
+        text-decoration-color: #ffffff; }
   @media (max-width: 979px) {
-    /* line 517, ../scss/stanford_bean_types_featured.scss */
+    /* line 530, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text {
       margin-top: 1%;
       position: relative;
       width: auto; }
-      /* line 542, ../scss/stanford_bean_types_featured.scss */
+      /* line 557, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead {
         padding-top: 0; } }
-  /* line 547, ../scss/stanford_bean_types_featured.scss */
+  /* line 562, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .group-headline-h2,
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead,
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-description,
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-more-link {
     color: #333333; }
-    /* line 553, ../scss/stanford_bean_types_featured.scss */
+    /* line 568, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .group-headline-h2 a,
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a,
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-description a,
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-more-link a {
       color: #333333; }
-      /* line 556, ../scss/stanford_bean_types_featured.scss */
+      /* line 571, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .group-headline-h2 a.btn,
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a.btn,
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-description a.btn,
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-more-link a.btn {
         color: #fff; }
 
-/* line 564, ../scss/stanford_bean_types_featured.scss */
+/* line 579, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured.has-video {
   background: #fff; }
-  /* line 567, ../scss/stanford_bean_types_featured.scss */
+  /* line 582, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
     float: left;
     height: 400px;
     width: 100%; }
     @media (max-width: 979px) {
-      /* line 567, ../scss/stanford_bean_types_featured.scss */
+      /* line 582, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
       .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
         width: 100%; } }
-  /* line 580, ../scss/stanford_bean_types_featured.scss */
+  /* line 595, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image {
     display: block; }
-    /* line 583, ../scss/stanford_bean_types_featured.scss */
+    /* line 598, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image img {
       height: 400px; }
-  /* line 588, ../scss/stanford_bean_types_featured.scss */
+  /* line 603, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
     position: relative; }
-  /* line 592, ../scss/stanford_bean_types_featured.scss */
+  /* line 607, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .group-overlay-text {
     background: #fff;
     color: #333333;
@@ -493,57 +507,56 @@ div[class*="featured"] .entity-paragraphs-item {
     top: 4%;
     width: 27%; }
     @media (max-width: 979px) {
-      /* line 592, ../scss/stanford_bean_types_featured.scss */
+      /* line 607, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .group-overlay-text {
         float: left;
         margin-left: 0;
         padding: 6%;
         text-align: center;
         width: 88%; } }
-    /* line 613, ../scss/stanford_bean_types_featured.scss */
+    /* line 628, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .group-overlay-text .group-headline-h2,
     .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead {
       color: #333333; }
-      /* line 617, ../scss/stanford_bean_types_featured.scss */
+      /* line 632, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .group-overlay-text .group-headline-h2 a,
       .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead a {
         color: #333333; }
-    /* line 622, ../scss/stanford_bean_types_featured.scss */
+    /* line 637, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead a:hover {
       text-decoration: underline;
       color: #333333; }
-    /* line 628, ../scss/stanford_bean_types_featured.scss */
+    /* line 643, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0; }
 
-/* line 636, ../scss/stanford_bean_types_featured.scss */
-.fullwidth .span6 .paragraphs-item-p-featured.has-video div.group-overlay-text {
+/* line 652, ../scss/stanford_bean_types_featured.scss */
+.fullwidth .span6 .paragraphs-item-p-featured.has-video div.group-overlay-text,
+.fullwidth .span9 .paragraphs-item-p-featured.has-video div.group-overlay-text {
   float: left;
   margin-left: 0;
   padding: 6%;
   position: relative;
   text-align: center;
-  width: 88%; }
-  @media (max-width: 979px) {
-    /* line 636, ../scss/stanford_bean_types_featured.scss */
-    .fullwidth .span6 .paragraphs-item-p-featured.has-video div.group-overlay-text {
-      width: auto; } }
-/* line 650, ../scss/stanford_bean_types_featured.scss */
+  width: auto; }
+/* line 661, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
-.fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
+.fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video,
+.fullwidth .span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
+.fullwidth .span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
   float: left;
   height: 400px;
   width: 100%; }
 
-/* line 659, ../scss/stanford_bean_types_featured.scss */
+/* line 670, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured div.group-overlay-text {
   max-height: 100%; }
   @media (max-width: 979px) {
-    /* line 659, ../scss/stanford_bean_types_featured.scss */
+    /* line 670, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured div.group-overlay-text {
       padding: 20px 20px 24px;
       width: auto; } }
-  /* line 668, ../scss/stanford_bean_types_featured.scss */
+  /* line 679, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn,
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
@@ -551,73 +564,73 @@ div[class*="featured"] .entity-paragraphs-item {
     margin-top: 22px;
     padding: 0.8em calc(6% - 40px); }
     @media (max-width: 979px) {
-      /* line 668, ../scss/stanford_bean_types_featured.scss */
+      /* line 679, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise {
         margin: 10px 0 10px;
         padding: 0.8em 1.2em 0.9em; } }
-  /* line 682, ../scss/stanford_bean_types_featured.scss */
+  /* line 693, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
     font-size: 22px; }
     @media (max-width: 979px) {
-      /* line 682, ../scss/stanford_bean_types_featured.scss */
+      /* line 693, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
         font-size: 16px;
         margin: 10px 0 0; } }
-    /* line 691, ../scss/stanford_bean_types_featured.scss */
+    /* line 702, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0 22%; }
       @media (max-width: 979px) {
-        /* line 691, ../scss/stanford_bean_types_featured.scss */
+        /* line 702, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
           padding-bottom: 0; } }
       @media (max-width: 580px) {
-        /* line 691, ../scss/stanford_bean_types_featured.scss */
+        /* line 702, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
           margin: 0 10%;
           padding-bottom: 30px; } }
-/* line 709, ../scss/stanford_bean_types_featured.scss */
+/* line 720, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
   font-size: 52px;
   margin: 10px 10%;
   width: 80%; }
   @media (max-width: 979px) {
-    /* line 709, ../scss/stanford_bean_types_featured.scss */
+    /* line 720, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 32px; } }
   @media (max-width: 580px) {
-    /* line 709, ../scss/stanford_bean_types_featured.scss */
+    /* line 720, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 26px;
       margin: 10px 0;
       width: 100%; } }
-/* line 727, ../scss/stanford_bean_types_featured.scss */
+/* line 738, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-description {
   font-size: 22px; }
   @media (max-width: 979px) {
-    /* line 727, ../scss/stanford_bean_types_featured.scss */
+    /* line 738, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-description {
       font-size: 20px; } }
-/* line 736, ../scss/stanford_bean_types_featured.scss */
+/* line 747, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-more-link {
   margin-top: 0; }
-/* line 741, ../scss/stanford_bean_types_featured.scss */
+/* line 752, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-video {
   background: #fff; }
-  /* line 744, ../scss/stanford_bean_types_featured.scss */
+  /* line 755, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
   .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
     float: left;
     height: 400px;
     width: 61%; }
     @media (max-width: 979px) {
-      /* line 744, ../scss/stanford_bean_types_featured.scss */
+      /* line 755, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
       .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
         width: 100%; } }
-  /* line 756, ../scss/stanford_bean_types_featured.scss */
+  /* line 767, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text {
     position: absolute;
     padding: 3% 3% 0;
@@ -632,7 +645,7 @@ div[class*="featured"] .entity-paragraphs-item {
     top: 4%;
     width: 27%; }
     @media (max-width: 979px) {
-      /* line 756, ../scss/stanford_bean_types_featured.scss */
+      /* line 767, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text {
         float: left;
         margin-left: 0;
@@ -640,35 +653,35 @@ div[class*="featured"] .entity-paragraphs-item {
         position: relative;
         text-align: center;
         width: 88%; } }
-    /* line 779, ../scss/stanford_bean_types_featured.scss */
+    /* line 790, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2,
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-superhead {
       color: #000; }
-      /* line 783, ../scss/stanford_bean_types_featured.scss */
+      /* line 794, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 a,
       .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-superhead a {
         color: #000; }
-    /* line 788, ../scss/stanford_bean_types_featured.scss */
+    /* line 799, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
       font-size: 32px;
       margin: 30px 0 0;
       width: 100%; }
       @media (max-width: 979px) {
-        /* line 788, ../scss/stanford_bean_types_featured.scss */
+        /* line 799, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
           font-size: 32px; } }
-    /* line 799, ../scss/stanford_bean_types_featured.scss */
+    /* line 810, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
       font-size: 22px; }
       @media (max-width: 979px) {
-        /* line 799, ../scss/stanford_bean_types_featured.scss */
+        /* line 810, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
           font-size: 20px; } }
-    /* line 808, ../scss/stanford_bean_types_featured.scss */
+    /* line 819, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0; }
 
-/* line 815, ../scss/stanford_bean_types_featured.scss */
+/* line 826, ../scss/stanford_bean_types_featured.scss */
 .entity-paragraphs-item iframe[src*="youtube"],
 .entity-paragraphs-item iframe[src*="vimeo"] {
   height: 400px; }

--- a/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
+++ b/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
@@ -36,134 +36,154 @@ div[class*="featured"] .entity-paragraphs-item {
     margin-left: 0;
     margin-right: 0; }
 
-/* line 47, ../scss/stanford_bean_types_featured.scss */
-.row-fluid .block-bean.well.featured-block {
-  margin-bottom: 0; }
-
 /* line 51, ../scss/stanford_bean_types_featured.scss */
-.span6 .featured-block {
-  margin-left: 0;
-  margin-right: 0; }
-
-/* line 60, ../scss/stanford_bean_types_featured.scss */
 .front .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
   margin-top: .2em;
   margin-bottom: 20px; }
 
-/* line 72, ../scss/stanford_bean_types_featured.scss */
+/* line 63, ../scss/stanford_bean_types_featured.scss */
 .front .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
   margin: 0 28%; }
   @media (max-width: 979px) {
-    /* line 72, ../scss/stanford_bean_types_featured.scss */
+    /* line 63, ../scss/stanford_bean_types_featured.scss */
     .front .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0 22%; } }
+  @media (max-width: 580px) {
+    /* line 63, ../scss/stanford_bean_types_featured.scss */
+    .front .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
+      margin: 0 12%; } }
+  @media (max-width: 480px) {
+    /* line 63, ../scss/stanford_bean_types_featured.scss */
+    .front .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
+      margin: 0; } }
 
-/* line 88, ../scss/stanford_bean_types_featured.scss */
+/* line 89, ../scss/stanford_bean_types_featured.scss */
 .front .span9 .paragraphs-item-p-featured.has-image .group-headline-h2,
 .span9 .paragraphs-item-p-featured.has-image .group-headline-h2 {
   font-size: 42px;
   margin-top: .2em;
   margin-bottom: 20px; }
   @media (max-width: 1199px) {
-    /* line 88, ../scss/stanford_bean_types_featured.scss */
+    /* line 89, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-item-p-featured.has-image .group-headline-h2,
     .span9 .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 36px; } }
   @media (max-width: 979px) {
-    /* line 88, ../scss/stanford_bean_types_featured.scss */
+    /* line 89, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-item-p-featured.has-image .group-headline-h2,
     .span9 .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 32px; } }
   @media (max-width: 767px) {
-    /* line 88, ../scss/stanford_bean_types_featured.scss */
+    /* line 89, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-item-p-featured.has-image .group-headline-h2,
     .span9 .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 28px; } }
-/* line 112, ../scss/stanford_bean_types_featured.scss */
+  @media (max-width: 480px) {
+    /* line 89, ../scss/stanford_bean_types_featured.scss */
+    .front .span9 .paragraphs-item-p-featured.has-image .group-headline-h2,
+    .span9 .paragraphs-item-p-featured.has-image .group-headline-h2 {
+      font-size: 24px; } }
+/* line 118, ../scss/stanford_bean_types_featured.scss */
 .front .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item,
 .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
   font-size: 22px;
   margin: 0 15%; }
   @media (max-width: 1199px) {
-    /* line 112, ../scss/stanford_bean_types_featured.scss */
+    /* line 118, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item,
     .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       font-size: 20px; } }
   @media (max-width: 979px) {
-    /* line 112, ../scss/stanford_bean_types_featured.scss */
+    /* line 118, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item,
     .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       font-size: 18px; } }
   @media (max-width: 767px) {
-    /* line 112, ../scss/stanford_bean_types_featured.scss */
+    /* line 118, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item,
     .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0 8%; } }
+  @media (max-width: 480px) {
+    /* line 118, ../scss/stanford_bean_types_featured.scss */
+    .front .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item,
+    .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
+      font-size: 16px; } }
 
-/* line 139, ../scss/stanford_bean_types_featured.scss */
+/* line 150, ../scss/stanford_bean_types_featured.scss */
 .front .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead,
 .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
   font-size: 20px; }
   @media (max-width: 1199px) {
-    /* line 139, ../scss/stanford_bean_types_featured.scss */
+    /* line 150, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead,
     .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
       font-size: 18px; } }
+  @media (max-width: 480px) {
+    /* line 150, ../scss/stanford_bean_types_featured.scss */
+    .front .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead,
+    .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
+      font-size: 16px; } }
 
-/* line 150, ../scss/stanford_bean_types_featured.scss */
+/* line 166, ../scss/stanford_bean_types_featured.scss */
 .front .block-bean.no-padding.well.featured-block {
   display: inline-block;
   margin: 0;
   width: 100%; }
-  /* line 155, ../scss/stanford_bean_types_featured.scss */
+  /* line 171, ../scss/stanford_bean_types_featured.scss */
   .front .block-bean.no-padding.well.featured-block.top-margin {
     margin-top: 100px; }
-  /* line 159, ../scss/stanford_bean_types_featured.scss */
+  /* line 175, ../scss/stanford_bean_types_featured.scss */
   .front .block-bean.no-padding.well.featured-block.bottom-margin {
     margin-bottom: 100px; }
-  /* line 163, ../scss/stanford_bean_types_featured.scss */
+  /* line 179, ../scss/stanford_bean_types_featured.scss */
   .front .block-bean.no-padding.well.featured-block.span9 {
     width: 62.5%;
     margin-left: 18.75%;
     margin-right: 18.75%; }
-  /* line 169, ../scss/stanford_bean_types_featured.scss */
+  /* line 185, ../scss/stanford_bean_types_featured.scss */
   .front .block-bean.no-padding.well.featured-block.span6 {
     width: 46.5%;
     margin-left: 26.75%;
     margin-right: 26.75%; }
 
 @media (max-width: 979px) {
-  /* line 178, ../scss/stanford_bean_types_featured.scss */
+  /* line 192, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured > .content .field-name-field-p-featured-image img {
     max-height: 250px;
     min-height: 200px; } }
-/* line 184, ../scss/stanford_bean_types_featured.scss */
+@media (max-width: 767px) {
+  /* line 192, ../scss/stanford_bean_types_featured.scss */
+  .paragraphs-item-p-featured > .content .field-name-field-p-featured-image img {
+    max-height: 150px;
+    min-height: 100px; } }
+
+/* line 207, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured {
   margin-bottom: 0; }
-  /* line 187, ../scss/stanford_bean_types_featured.scss */
+  /* line 210, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured a.play-video {
     color: #ffffff;
     display: block;
     font-size: 0;
     z-index: 3; }
-  /* line 194, ../scss/stanford_bean_types_featured.scss */
+  /* line 217, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured .field-name-field-p-featured-image {
     background: #001933;
     position: relative;
     z-index: 2; }
-    /* line 199, ../scss/stanford_bean_types_featured.scss */
+    /* line 222, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured .field-name-field-p-featured-image img {
       height: auto;
       opacity: .3;
       width: 100%; }
-  /* line 206, ../scss/stanford_bean_types_featured.scss */
+  /* line 229, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured .field-name-field-p-featured-video {
     height: auto;
     position: absolute;
     width: 100%;
     top: -20px;
     z-index: 1; }
-  /* line 214, ../scss/stanford_bean_types_featured.scss */
+  /* line 237, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured div.group-overlay-text {
     background-color: transparent;
     color: #fff;
@@ -177,28 +197,28 @@ div[class*="featured"] .entity-paragraphs-item {
     width: 100%;
     z-index: 2; }
     @media (max-width: 979px) {
-      /* line 214, ../scss/stanford_bean_types_featured.scss */
+      /* line 237, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text {
         position: relative;
         width: 100%; } }
-    /* line 233, ../scss/stanford_bean_types_featured.scss */
+    /* line 256, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text > div,
     .paragraphs-item-p-featured div.group-overlay-text > h2 {
       display: table-cell;
       float: left;
       vertical-align: middle;
       width: 100%; }
-    /* line 241, ../scss/stanford_bean_types_featured.scss */
+    /* line 264, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 {
       color: #ffffff;
       font-size: 32px;
       line-height: 1.1em;
       margin: 10px 0 0; }
       @media (max-width: 580px) {
-        /* line 241, ../scss/stanford_bean_types_featured.scss */
+        /* line 264, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 {
           font-size: 24px; } }
-      /* line 252, ../scss/stanford_bean_types_featured.scss */
+      /* line 275, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 a {
         background-color: transparent;
         box-shadow: none;
@@ -207,68 +227,68 @@ div[class*="featured"] .entity-paragraphs-item {
         padding: 0;
         -webkit-text-decoration-color: #00ece9;
         text-decoration-color: #00ece9; }
-        /* line 261, ../scss/stanford_bean_types_featured.scss */
+        /* line 284, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 a:after {
           content: ''; }
-        /* line 265, ../scss/stanford_bean_types_featured.scss */
+        /* line 288, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 a:hover {
           -webkit-text-decoration-color: #ffffff;
           text-decoration-color: #ffffff; }
-    /* line 272, ../scss/stanford_bean_types_featured.scss */
+    /* line 295, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
       font-size: 20px;
       font-weight: 600;
       letter-spacing: 0; }
-      /* line 277, ../scss/stanford_bean_types_featured.scss */
+      /* line 300, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead a {
         color: #ffbd54;
         text-decoration: none;
         -webkit-text-decoration-color: #ffbd54;
         text-decoration-color: #ffbd54; }
-        /* line 283, ../scss/stanford_bean_types_featured.scss */
+        /* line 306, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead a:hover {
           color: #ffffff;
           text-decoration: underline;
           -webkit-text-decoration-color: #ffffff;
           text-decoration-color: #ffffff; }
-    /* line 292, ../scss/stanford_bean_types_featured.scss */
+    /* line 315, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
       font-size: 18px;
       line-height: 1.2em;
       margin: 20px 0 0; }
       @media (max-width: 767px) {
-        /* line 292, ../scss/stanford_bean_types_featured.scss */
+        /* line 315, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
           margin: 20px 0; } }
-      /* line 302, ../scss/stanford_bean_types_featured.scss */
+      /* line 325, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
         line-height: 1.3em;
         margin: 0 10%; }
-    /* line 308, ../scss/stanford_bean_types_featured.scss */
+    /* line 331, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link {
       margin-top: 30px; }
       @media (max-width: 979px) {
-        /* line 308, ../scss/stanford_bean_types_featured.scss */
+        /* line 331, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link {
           margin-bottom: 30px; } }
-      /* line 316, ../scss/stanford_bean_types_featured.scss */
+      /* line 339, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a {
         color: #ffffff;
         text-decoration: underline;
         -webkit-text-decoration-color: #ff525c;
         text-decoration-color: #ff525c; }
-        /* line 322, ../scss/stanford_bean_types_featured.scss */
+        /* line 345, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a:hover {
           -webkit-text-decoration-color: #ffffff;
           text-decoration-color: #ffffff; }
-        /* line 327, ../scss/stanford_bean_types_featured.scss */
+        /* line 350, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a:after {
           content: ' ›'; }
         @media (max-width: 979px) {
-          /* line 316, ../scss/stanford_bean_types_featured.scss */
+          /* line 339, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a {
             color: #333333; } }
-    /* line 338, ../scss/stanford_bean_types_featured.scss */
+    /* line 361, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
     .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
     .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise {
@@ -286,18 +306,18 @@ div[class*="featured"] .entity-paragraphs-item {
       padding: 0.8em 1.2em 0.9em;
       text-align: center;
       text-decoration: none; }
-      /* line 356, ../scss/stanford_bean_types_featured.scss */
+      /* line 379, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text a.btn-orange:after,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-pink:after,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise:after {
         content: ''; }
-      /* line 360, ../scss/stanford_bean_types_featured.scss */
+      /* line 383, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text a.btn-orange:hover,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-pink:hover,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise:hover {
         background: #333333;
         color: #fff; }
-    /* line 366, ../scss/stanford_bean_types_featured.scss */
+    /* line 389, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text a.btn {
       -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
       -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
@@ -312,165 +332,155 @@ div[class*="featured"] .entity-paragraphs-item {
       padding: 0.8em 1.2em 0.9em;
       text-align: center;
       text-decoration: none; }
-      /* line 381, ../scss/stanford_bean_types_featured.scss */
+      /* line 404, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text a.btn:after {
         content: ''; }
 
-/* line 391, ../scss/stanford_bean_types_featured.scss */
+/* line 414, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
   font-size: 22px; }
   @media (max-width: 979px) {
-    /* line 391, ../scss/stanford_bean_types_featured.scss */
+    /* line 414, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
       font-size: 18px; } }
 
-/* line 405, ../scss/stanford_bean_types_featured.scss */
+/* line 428, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-image .field-name-field-p-featured-image {
   width: 100%; }
-/* line 409, ../scss/stanford_bean_types_featured.scss */
+/* line 432, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-image .group-overlay-text {
   margin-top: 1%;
   position: relative;
   width: 100%; }
-  /* line 414, ../scss/stanford_bean_types_featured.scss */
+  /* line 437, ../scss/stanford_bean_types_featured.scss */
   .span6 .paragraphs-item-p-featured.has-image .group-overlay-text .field-name-field-p-featured-superhead {
     padding-top: 40px; }
-/* line 421, ../scss/stanford_bean_types_featured.scss */
+/* line 444, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
   width: 100%; }
-/* line 425, ../scss/stanford_bean_types_featured.scss */
+/* line 448, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-video .group-overlay-text {
   margin-top: 1%;
   position: relative;
   width: 100%; }
-  /* line 430, ../scss/stanford_bean_types_featured.scss */
+  /* line 453, ../scss/stanford_bean_types_featured.scss */
   .span6 .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead {
     padding-top: 40px; }
 
-/* line 438, ../scss/stanford_bean_types_featured.scss */
+/* line 461, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured.has-image div.group-overlay-text {
   background: transparent;
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%); }
-  /* line 445, ../scss/stanford_bean_types_featured.scss */
+  /* line 468, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead {
     padding-top: 20px; }
-    /* line 448, ../scss/stanford_bean_types_featured.scss */
+    /* line 471, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a {
       color: #ffbd54;
       text-decoration: none; }
-      /* line 452, ../scss/stanford_bean_types_featured.scss */
+      /* line 475, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a:hover {
         color: #ffffff;
         text-decoration: underline; }
   @media (max-width: 979px) {
-    /* line 438, ../scss/stanford_bean_types_featured.scss */
+    /* line 461, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image div.group-overlay-text {
       left: initial;
       position: relative;
       transform: none; }
-      /* line 465, ../scss/stanford_bean_types_featured.scss */
+      /* line 488, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead {
         padding-top: 20px; }
-        /* line 468, ../scss/stanford_bean_types_featured.scss */
+        /* line 491, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a {
           color: #b1040e;
           text-decoration: none; }
-          /* line 472, ../scss/stanford_bean_types_featured.scss */
+          /* line 495, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a:hover {
             color: #333333;
             text-decoration: underline;
             -webkit-text-decoration-color: #333333;
             text-decoration-color: #333333; }
-      /* line 481, ../scss/stanford_bean_types_featured.scss */
+      /* line 504, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image div.group-overlay-text .group-headline-h2,
       .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-description {
         color: #333333; }
-        /* line 485, ../scss/stanford_bean_types_featured.scss */
+        /* line 508, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-image div.group-overlay-text .group-headline-h2 a,
         .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-description a {
           color: #333333; } }
 
-/* line 494, ../scss/stanford_bean_types_featured.scss */
+/* line 517, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured.has-image.has-video .group-overlay-text {
   background: transparent;
   left: 0;
   position: absolute;
   transform: none; }
-  /* line 501, ../scss/stanford_bean_types_featured.scss */
+  /* line 524, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a {
     text-decoration: underline;
     -webkit-text-decoration-color: #ffbd54;
     text-decoration-color: #ffbd54; }
-    /* line 506, ../scss/stanford_bean_types_featured.scss */
+    /* line 529, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a:hover {
       color: #333333;
       -webkit-text-decoration-color: #ffffff;
       text-decoration-color: #ffffff; }
   @media (max-width: 979px) {
-    /* line 494, ../scss/stanford_bean_types_featured.scss */
+    /* line 517, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text {
       margin-top: 1%;
       position: relative;
       width: auto; }
-      /* line 519, ../scss/stanford_bean_types_featured.scss */
+      /* line 542, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead {
         padding-top: 0; } }
-  /* line 524, ../scss/stanford_bean_types_featured.scss */
+  /* line 547, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .group-headline-h2,
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead,
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-description,
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-more-link {
     color: #333333; }
-    /* line 530, ../scss/stanford_bean_types_featured.scss */
+    /* line 553, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .group-headline-h2 a,
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a,
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-description a,
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-more-link a {
       color: #333333; }
-      /* line 533, ../scss/stanford_bean_types_featured.scss */
+      /* line 556, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .group-headline-h2 a.btn,
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a.btn,
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-description a.btn,
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-more-link a.btn {
         color: #fff; }
 
-/* line 543, ../scss/stanford_bean_types_featured.scss */
-.span6 .paragraphs-item-p-featured.has-image.has-video .field-name-field-p-featured-image,
-.span6 .paragraphs-item-p-featured.has-image.has-video .field-name-field-p-featured-video {
-  width: 100%; }
-/* line 548, ../scss/stanford_bean_types_featured.scss */
-.span6 .paragraphs-item-p-featured.has-image.has-video .group-overlay-text {
-  background: transparent;
-  position: relative;
-  width: 100%; }
-
-/* line 556, ../scss/stanford_bean_types_featured.scss */
+/* line 564, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured.has-video {
   background: #fff; }
-  /* line 559, ../scss/stanford_bean_types_featured.scss */
+  /* line 567, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
     float: left;
     height: 400px;
-    width: 61%; }
+    width: 100%; }
     @media (max-width: 979px) {
-      /* line 559, ../scss/stanford_bean_types_featured.scss */
+      /* line 567, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
       .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
         width: 100%; } }
-  /* line 572, ../scss/stanford_bean_types_featured.scss */
+  /* line 580, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image {
     display: block; }
-    /* line 575, ../scss/stanford_bean_types_featured.scss */
+    /* line 583, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image img {
       height: 400px; }
-  /* line 580, ../scss/stanford_bean_types_featured.scss */
+  /* line 588, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
     position: relative; }
-  /* line 584, ../scss/stanford_bean_types_featured.scss */
+  /* line 592, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .group-overlay-text {
     background: #fff;
     color: #333333;
@@ -483,34 +493,57 @@ div[class*="featured"] .entity-paragraphs-item {
     top: 4%;
     width: 27%; }
     @media (max-width: 979px) {
-      /* line 584, ../scss/stanford_bean_types_featured.scss */
+      /* line 592, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .group-overlay-text {
         float: left;
         margin-left: 0;
         padding: 6%;
         text-align: center;
         width: 88%; } }
-    /* line 605, ../scss/stanford_bean_types_featured.scss */
+    /* line 613, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .group-overlay-text .group-headline-h2,
     .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead {
       color: #333333; }
-      /* line 609, ../scss/stanford_bean_types_featured.scss */
+      /* line 617, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .group-overlay-text .group-headline-h2 a,
       .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead a {
         color: #333333; }
-    /* line 615, ../scss/stanford_bean_types_featured.scss */
+    /* line 622, ../scss/stanford_bean_types_featured.scss */
+    .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead a:hover {
+      text-decoration: underline;
+      color: #333333; }
+    /* line 628, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0; }
 
-/* line 623, ../scss/stanford_bean_types_featured.scss */
+/* line 636, ../scss/stanford_bean_types_featured.scss */
+.fullwidth .span6 .paragraphs-item-p-featured.has-video div.group-overlay-text {
+  float: left;
+  margin-left: 0;
+  padding: 6%;
+  position: relative;
+  text-align: center;
+  width: 88%; }
+  @media (max-width: 979px) {
+    /* line 636, ../scss/stanford_bean_types_featured.scss */
+    .fullwidth .span6 .paragraphs-item-p-featured.has-video div.group-overlay-text {
+      width: auto; } }
+/* line 650, ../scss/stanford_bean_types_featured.scss */
+.fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
+.fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
+  float: left;
+  height: 400px;
+  width: 100%; }
+
+/* line 659, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured div.group-overlay-text {
   max-height: 100%; }
   @media (max-width: 979px) {
-    /* line 623, ../scss/stanford_bean_types_featured.scss */
+    /* line 659, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured div.group-overlay-text {
       padding: 20px 20px 24px;
       width: auto; } }
-  /* line 632, ../scss/stanford_bean_types_featured.scss */
+  /* line 668, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn,
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
@@ -518,81 +551,124 @@ div[class*="featured"] .entity-paragraphs-item {
     margin-top: 22px;
     padding: 0.8em calc(6% - 40px); }
     @media (max-width: 979px) {
-      /* line 632, ../scss/stanford_bean_types_featured.scss */
+      /* line 668, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise {
         margin: 10px 0 10px;
         padding: 0.8em 1.2em 0.9em; } }
-  /* line 646, ../scss/stanford_bean_types_featured.scss */
+  /* line 682, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
     font-size: 22px; }
     @media (max-width: 979px) {
-      /* line 646, ../scss/stanford_bean_types_featured.scss */
+      /* line 682, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
         font-size: 16px;
         margin: 10px 0 0; } }
-    /* line 655, ../scss/stanford_bean_types_featured.scss */
+    /* line 691, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0 22%; }
       @media (max-width: 979px) {
-        /* line 655, ../scss/stanford_bean_types_featured.scss */
+        /* line 691, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
           padding-bottom: 0; } }
       @media (max-width: 580px) {
-        /* line 655, ../scss/stanford_bean_types_featured.scss */
+        /* line 691, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
           margin: 0 10%;
           padding-bottom: 30px; } }
-/* line 673, ../scss/stanford_bean_types_featured.scss */
+/* line 709, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
   font-size: 52px;
   margin: 10px 10%;
   width: 80%; }
   @media (max-width: 979px) {
-    /* line 673, ../scss/stanford_bean_types_featured.scss */
+    /* line 709, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 32px; } }
   @media (max-width: 580px) {
-    /* line 673, ../scss/stanford_bean_types_featured.scss */
+    /* line 709, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
-      font-size: 26px; } }
-/* line 689, ../scss/stanford_bean_types_featured.scss */
+      font-size: 26px;
+      margin: 10px 0;
+      width: 100%; } }
+/* line 727, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-description {
   font-size: 22px; }
   @media (max-width: 979px) {
-    /* line 689, ../scss/stanford_bean_types_featured.scss */
+    /* line 727, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-description {
       font-size: 20px; } }
-/* line 698, ../scss/stanford_bean_types_featured.scss */
+/* line 736, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-more-link {
   margin-top: 0; }
-/* line 704, ../scss/stanford_bean_types_featured.scss */
-.fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text {
-  margin-top: 0;
-  padding: 3% 3% 0; }
-  /* line 708, ../scss/stanford_bean_types_featured.scss */
-  .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
-    font-size: 32px;
-    margin: 30px 0 0;
-    width: auto; }
+/* line 741, ../scss/stanford_bean_types_featured.scss */
+.fullwidth .paragraphs-item-p-featured.has-video {
+  background: #fff; }
+  /* line 744, ../scss/stanford_bean_types_featured.scss */
+  .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
+  .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
+    float: left;
+    height: 400px;
+    width: 61%; }
     @media (max-width: 979px) {
-      /* line 708, ../scss/stanford_bean_types_featured.scss */
-      .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
-        font-size: 32px; } }
-  /* line 719, ../scss/stanford_bean_types_featured.scss */
-  .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
-    font-size: 22px; }
+      /* line 744, ../scss/stanford_bean_types_featured.scss */
+      .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
+      .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
+        width: 100%; } }
+  /* line 756, ../scss/stanford_bean_types_featured.scss */
+  .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text {
+    position: absolute;
+    padding: 3% 3% 0;
+    background: #fff;
+    color: #000;
+    display: block;
+    float: right;
+    height: auto;
+    margin-left: 61%;
+    padding: 4% 6% 0;
+    text-align: left;
+    top: 4%;
+    width: 27%; }
     @media (max-width: 979px) {
-      /* line 719, ../scss/stanford_bean_types_featured.scss */
-      .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
-        font-size: 20px; } }
-  /* line 728, ../scss/stanford_bean_types_featured.scss */
-  .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description .field-item {
-    margin: 0; }
+      /* line 756, ../scss/stanford_bean_types_featured.scss */
+      .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text {
+        float: left;
+        margin-left: 0;
+        padding: 6%;
+        position: relative;
+        text-align: center;
+        width: 88%; } }
+    /* line 779, ../scss/stanford_bean_types_featured.scss */
+    .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2,
+    .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-superhead {
+      color: #000; }
+      /* line 783, ../scss/stanford_bean_types_featured.scss */
+      .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 a,
+      .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-superhead a {
+        color: #000; }
+    /* line 788, ../scss/stanford_bean_types_featured.scss */
+    .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
+      font-size: 32px;
+      margin: 30px 0 0;
+      width: 100%; }
+      @media (max-width: 979px) {
+        /* line 788, ../scss/stanford_bean_types_featured.scss */
+        .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
+          font-size: 32px; } }
+    /* line 799, ../scss/stanford_bean_types_featured.scss */
+    .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
+      font-size: 22px; }
+      @media (max-width: 979px) {
+        /* line 799, ../scss/stanford_bean_types_featured.scss */
+        .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
+          font-size: 20px; } }
+    /* line 808, ../scss/stanford_bean_types_featured.scss */
+    .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description .field-item {
+      margin: 0; }
 
-/* line 735, ../scss/stanford_bean_types_featured.scss */
+/* line 815, ../scss/stanford_bean_types_featured.scss */
 .entity-paragraphs-item iframe[src*="youtube"],
 .entity-paragraphs-item iframe[src*="vimeo"] {
   height: 400px; }

--- a/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
+++ b/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
@@ -165,8 +165,8 @@ div[class*="featured"] .entity-paragraphs-item {
 @media (max-width: 767px) {
   /* line 206, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video > .content .field-name-field-p-featured-image img {
-    max-height: 200px;
-    min-height: 100px; } }
+    max-height: 300px;
+    min-height: 200px; } }
 
 /* line 220, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured {
@@ -529,34 +529,120 @@ div[class*="featured"] .entity-paragraphs-item {
     /* line 643, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0; }
+    /* line 648, ../scss/stanford_bean_types_featured.scss */
+    .paragraphs-item-p-featured.has-video .group-overlay-text.has-video {
+      background: #fff; }
+      /* line 651, ../scss/stanford_bean_types_featured.scss */
+      .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-image,
+      .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-video {
+        float: left;
+        height: 400px;
+        width: 61%; }
+        @media (max-width: 979px) {
+          /* line 651, ../scss/stanford_bean_types_featured.scss */
+          .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-image,
+          .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-video {
+            width: 100%; } }
+        @media (max-width: 767px) {
+          /* line 651, ../scss/stanford_bean_types_featured.scss */
+          .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-image,
+          .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-video {
+            height: 300px; } }
+      /* line 668, ../scss/stanford_bean_types_featured.scss */
+      .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text {
+        position: absolute;
+        padding: 3% 3% 0;
+        background: #fff;
+        color: #000;
+        display: block;
+        float: right;
+        height: auto;
+        margin-left: 61%;
+        padding: 4% 6% 0;
+        text-align: left;
+        top: 4%;
+        width: 27%; }
+        @media (max-width: 979px) {
+          /* line 668, ../scss/stanford_bean_types_featured.scss */
+          .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text {
+            float: left;
+            margin-left: 0;
+            padding: 3% 6% 6%;
+            position: relative;
+            text-align: center;
+            width: 88%; } }
+        /* line 691, ../scss/stanford_bean_types_featured.scss */
+        .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2,
+        .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-superhead {
+          color: #000; }
+          /* line 695, ../scss/stanford_bean_types_featured.scss */
+          .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2 a,
+          .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-superhead a {
+            color: #000; }
+        /* line 700, ../scss/stanford_bean_types_featured.scss */
+        .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2 {
+          font-size: 32px;
+          margin: 30px 0 20px;
+          width: 100%; }
+          @media (max-width: 979px) {
+            /* line 700, ../scss/stanford_bean_types_featured.scss */
+            .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2 {
+              font-size: 32px; } }
+        /* line 711, ../scss/stanford_bean_types_featured.scss */
+        .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-description {
+          font-size: 22px; }
+          @media (max-width: 979px) {
+            /* line 711, ../scss/stanford_bean_types_featured.scss */
+            .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-description {
+              font-size: 20px; } }
+        /* line 720, ../scss/stanford_bean_types_featured.scss */
+        .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-description .field-item {
+          margin: 0; }
 
-/* line 652, ../scss/stanford_bean_types_featured.scss */
+/* line 732, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .span6 .paragraphs-item-p-featured.has-video div.group-overlay-text,
-.fullwidth .span9 .paragraphs-item-p-featured.has-video div.group-overlay-text {
+.fullwidth .span9 .paragraphs-item-p-featured.has-video div.group-overlay-text,
+.span6 .paragraphs-item-p-featured.has-video div.group-overlay-text,
+.span9 .paragraphs-item-p-featured.has-video div.group-overlay-text {
   float: left;
   margin-left: 0;
-  padding: 6%;
+  padding: 4% 6% 6%;
   position: relative;
   text-align: center;
   width: auto; }
-/* line 661, ../scss/stanford_bean_types_featured.scss */
+/* line 741, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
 .fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video,
 .fullwidth .span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
-.fullwidth .span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
+.fullwidth .span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video,
+.span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
+.span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video,
+.span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
+.span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
   float: left;
   height: 400px;
   width: 100%; }
+  @media (max-width: 767px) {
+    /* line 741, ../scss/stanford_bean_types_featured.scss */
+    .fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
+    .fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video,
+    .fullwidth .span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
+    .fullwidth .span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video,
+    .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
+    .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video,
+    .span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
+    .span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
+      height: 300px; } }
 
-/* line 670, ../scss/stanford_bean_types_featured.scss */
+/* line 755, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured div.group-overlay-text {
   max-height: 100%; }
   @media (max-width: 979px) {
-    /* line 670, ../scss/stanford_bean_types_featured.scss */
+    /* line 755, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured div.group-overlay-text {
       padding: 20px 20px 24px;
       width: auto; } }
-  /* line 679, ../scss/stanford_bean_types_featured.scss */
+  /* line 764, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn,
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
@@ -564,73 +650,78 @@ div[class*="featured"] .entity-paragraphs-item {
     margin-top: 22px;
     padding: 0.8em calc(6% - 40px); }
     @media (max-width: 979px) {
-      /* line 679, ../scss/stanford_bean_types_featured.scss */
+      /* line 764, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise {
         margin: 10px 0 10px;
         padding: 0.8em 1.2em 0.9em; } }
-  /* line 693, ../scss/stanford_bean_types_featured.scss */
+  /* line 778, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
     font-size: 22px; }
     @media (max-width: 979px) {
-      /* line 693, ../scss/stanford_bean_types_featured.scss */
+      /* line 778, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
         font-size: 16px;
         margin: 10px 0 0; } }
-    /* line 702, ../scss/stanford_bean_types_featured.scss */
+    /* line 787, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0 22%; }
       @media (max-width: 979px) {
-        /* line 702, ../scss/stanford_bean_types_featured.scss */
+        /* line 787, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
           padding-bottom: 0; } }
       @media (max-width: 580px) {
-        /* line 702, ../scss/stanford_bean_types_featured.scss */
+        /* line 787, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
           margin: 0 10%;
           padding-bottom: 30px; } }
-/* line 720, ../scss/stanford_bean_types_featured.scss */
+/* line 805, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
   font-size: 52px;
   margin: 10px 10%;
   width: 80%; }
   @media (max-width: 979px) {
-    /* line 720, ../scss/stanford_bean_types_featured.scss */
+    /* line 805, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 32px; } }
   @media (max-width: 580px) {
-    /* line 720, ../scss/stanford_bean_types_featured.scss */
+    /* line 805, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 26px;
       margin: 10px 0;
       width: 100%; } }
-/* line 738, ../scss/stanford_bean_types_featured.scss */
+/* line 823, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-description {
   font-size: 22px; }
   @media (max-width: 979px) {
-    /* line 738, ../scss/stanford_bean_types_featured.scss */
+    /* line 823, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-description {
       font-size: 20px; } }
-/* line 747, ../scss/stanford_bean_types_featured.scss */
+/* line 832, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-more-link {
   margin-top: 0; }
-/* line 752, ../scss/stanford_bean_types_featured.scss */
+/* line 837, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-video {
   background: #fff; }
-  /* line 755, ../scss/stanford_bean_types_featured.scss */
+  /* line 840, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
   .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
     float: left;
     height: 400px;
     width: 61%; }
     @media (max-width: 979px) {
-      /* line 755, ../scss/stanford_bean_types_featured.scss */
+      /* line 840, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
       .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
         width: 100%; } }
-  /* line 767, ../scss/stanford_bean_types_featured.scss */
+    @media (max-width: 767px) {
+      /* line 840, ../scss/stanford_bean_types_featured.scss */
+      .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
+      .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
+        height: 300px; } }
+  /* line 857, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text {
     position: absolute;
     padding: 3% 3% 0;
@@ -645,43 +736,43 @@ div[class*="featured"] .entity-paragraphs-item {
     top: 4%;
     width: 27%; }
     @media (max-width: 979px) {
-      /* line 767, ../scss/stanford_bean_types_featured.scss */
+      /* line 857, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text {
         float: left;
         margin-left: 0;
-        padding: 6%;
+        padding: 3% 6% 6%;
         position: relative;
         text-align: center;
         width: 88%; } }
-    /* line 790, ../scss/stanford_bean_types_featured.scss */
+    /* line 880, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2,
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-superhead {
       color: #000; }
-      /* line 794, ../scss/stanford_bean_types_featured.scss */
+      /* line 884, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 a,
       .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-superhead a {
         color: #000; }
-    /* line 799, ../scss/stanford_bean_types_featured.scss */
+    /* line 889, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
       font-size: 32px;
-      margin: 30px 0 0;
+      margin: 30px 0 20px;
       width: 100%; }
       @media (max-width: 979px) {
-        /* line 799, ../scss/stanford_bean_types_featured.scss */
+        /* line 889, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
           font-size: 32px; } }
-    /* line 810, ../scss/stanford_bean_types_featured.scss */
+    /* line 900, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
       font-size: 22px; }
       @media (max-width: 979px) {
-        /* line 810, ../scss/stanford_bean_types_featured.scss */
+        /* line 900, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
           font-size: 20px; } }
-    /* line 819, ../scss/stanford_bean_types_featured.scss */
+    /* line 909, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0; }
 
-/* line 826, ../scss/stanford_bean_types_featured.scss */
+/* line 916, ../scss/stanford_bean_types_featured.scss */
 .entity-paragraphs-item iframe[src*="youtube"],
 .entity-paragraphs-item iframe[src*="vimeo"] {
   height: 400px; }

--- a/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
+++ b/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
@@ -40,161 +40,159 @@ div[class*="featured"] .entity-paragraphs-item {
 .front .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
   margin-top: .2em;
   margin-bottom: 20px; }
-
-/* line 63, ../scss/stanford_bean_types_featured.scss */
+/* line 59, ../scss/stanford_bean_types_featured.scss */
 .front .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
   margin: 0 28%; }
   @media (max-width: 979px) {
-    /* line 63, ../scss/stanford_bean_types_featured.scss */
+    /* line 59, ../scss/stanford_bean_types_featured.scss */
     .front .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0 22%; } }
   @media (max-width: 580px) {
-    /* line 63, ../scss/stanford_bean_types_featured.scss */
+    /* line 59, ../scss/stanford_bean_types_featured.scss */
     .front .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0 12%; } }
   @media (max-width: 480px) {
-    /* line 63, ../scss/stanford_bean_types_featured.scss */
+    /* line 59, ../scss/stanford_bean_types_featured.scss */
     .front .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0; } }
 
-/* line 89, ../scss/stanford_bean_types_featured.scss */
+/* line 87, ../scss/stanford_bean_types_featured.scss */
 .front .span9 .paragraphs-item-p-featured.has-image .group-headline-h2,
 .span9 .paragraphs-item-p-featured.has-image .group-headline-h2 {
   font-size: 42px;
   margin-top: .2em;
   margin-bottom: 20px; }
   @media (max-width: 1199px) {
-    /* line 89, ../scss/stanford_bean_types_featured.scss */
+    /* line 87, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-item-p-featured.has-image .group-headline-h2,
     .span9 .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 36px; } }
   @media (max-width: 979px) {
-    /* line 89, ../scss/stanford_bean_types_featured.scss */
+    /* line 87, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-item-p-featured.has-image .group-headline-h2,
     .span9 .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 32px; } }
   @media (max-width: 767px) {
-    /* line 89, ../scss/stanford_bean_types_featured.scss */
+    /* line 87, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-item-p-featured.has-image .group-headline-h2,
     .span9 .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 28px; } }
   @media (max-width: 480px) {
-    /* line 89, ../scss/stanford_bean_types_featured.scss */
+    /* line 87, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-item-p-featured.has-image .group-headline-h2,
     .span9 .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 24px; } }
-/* line 118, ../scss/stanford_bean_types_featured.scss */
+/* line 116, ../scss/stanford_bean_types_featured.scss */
 .front .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item,
 .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
   font-size: 22px;
   margin: 0 15%; }
   @media (max-width: 1199px) {
-    /* line 118, ../scss/stanford_bean_types_featured.scss */
+    /* line 116, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item,
     .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       font-size: 20px; } }
   @media (max-width: 979px) {
-    /* line 118, ../scss/stanford_bean_types_featured.scss */
+    /* line 116, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item,
     .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       font-size: 18px; } }
   @media (max-width: 767px) {
-    /* line 118, ../scss/stanford_bean_types_featured.scss */
+    /* line 116, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item,
     .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0 8%; } }
   @media (max-width: 480px) {
-    /* line 118, ../scss/stanford_bean_types_featured.scss */
+    /* line 116, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item,
     .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       font-size: 16px; } }
-
-/* line 150, ../scss/stanford_bean_types_featured.scss */
+/* line 147, ../scss/stanford_bean_types_featured.scss */
 .front .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead,
 .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
   font-size: 20px; }
   @media (max-width: 1199px) {
-    /* line 150, ../scss/stanford_bean_types_featured.scss */
+    /* line 147, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead,
     .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
       font-size: 18px; } }
   @media (max-width: 480px) {
-    /* line 150, ../scss/stanford_bean_types_featured.scss */
+    /* line 147, ../scss/stanford_bean_types_featured.scss */
     .front .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead,
     .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
       font-size: 16px; } }
 
-/* line 166, ../scss/stanford_bean_types_featured.scss */
+/* line 165, ../scss/stanford_bean_types_featured.scss */
 .front .block-bean.no-padding.well.featured-block {
   display: inline-block;
   margin: 0;
   width: 100%; }
-  /* line 171, ../scss/stanford_bean_types_featured.scss */
+  /* line 170, ../scss/stanford_bean_types_featured.scss */
   .front .block-bean.no-padding.well.featured-block.top-margin {
     margin-top: 100px; }
-  /* line 175, ../scss/stanford_bean_types_featured.scss */
+  /* line 174, ../scss/stanford_bean_types_featured.scss */
   .front .block-bean.no-padding.well.featured-block.bottom-margin {
     margin-bottom: 100px; }
-  /* line 179, ../scss/stanford_bean_types_featured.scss */
+  /* line 178, ../scss/stanford_bean_types_featured.scss */
   .front .block-bean.no-padding.well.featured-block.span9 {
     width: 62.5%;
     margin-left: 18.75%;
     margin-right: 18.75%; }
-  /* line 185, ../scss/stanford_bean_types_featured.scss */
+  /* line 184, ../scss/stanford_bean_types_featured.scss */
   .front .block-bean.no-padding.well.featured-block.span6 {
     width: 46.5%;
     margin-left: 26.75%;
     margin-right: 26.75%; }
 
 @media (max-width: 979px) {
-  /* line 192, ../scss/stanford_bean_types_featured.scss */
+  /* line 191, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured > .content .field-name-field-p-featured-image img {
     max-height: 400px;
     min-height: 200px; } }
 @media (max-width: 767px) {
-  /* line 192, ../scss/stanford_bean_types_featured.scss */
+  /* line 191, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured > .content .field-name-field-p-featured-image img {
     max-height: 300px;
     min-height: 200px; } }
 
 @media (max-width: 979px) {
-  /* line 206, ../scss/stanford_bean_types_featured.scss */
+  /* line 205, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video > .content .field-name-field-p-featured-image img {
     max-height: 400px;
     min-height: 200px; } }
 @media (max-width: 767px) {
-  /* line 206, ../scss/stanford_bean_types_featured.scss */
+  /* line 205, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video > .content .field-name-field-p-featured-image img {
     max-height: 300px;
     min-height: 200px; } }
 
-/* line 220, ../scss/stanford_bean_types_featured.scss */
+/* line 219, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured {
   margin-bottom: 0; }
-  /* line 223, ../scss/stanford_bean_types_featured.scss */
+  /* line 222, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured a.play-video {
     color: #ffffff;
     display: block;
     font-size: 0;
     z-index: 3; }
-  /* line 230, ../scss/stanford_bean_types_featured.scss */
+  /* line 229, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured .field-name-field-p-featured-image {
     background: #001933;
     position: relative;
     z-index: 2; }
-    /* line 235, ../scss/stanford_bean_types_featured.scss */
+    /* line 234, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured .field-name-field-p-featured-image img {
       height: auto;
       opacity: .3;
       width: 100%; }
-  /* line 242, ../scss/stanford_bean_types_featured.scss */
+  /* line 241, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured .field-name-field-p-featured-video {
     height: auto;
     position: absolute;
     width: 100%;
     top: -20px;
     z-index: 1; }
-  /* line 250, ../scss/stanford_bean_types_featured.scss */
+  /* line 249, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured div.group-overlay-text {
     background-color: transparent;
     color: #fff;
@@ -208,28 +206,28 @@ div[class*="featured"] .entity-paragraphs-item {
     width: 100%;
     z-index: 2; }
     @media (max-width: 979px) {
-      /* line 250, ../scss/stanford_bean_types_featured.scss */
+      /* line 249, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text {
         position: relative;
         width: 100%; } }
-    /* line 269, ../scss/stanford_bean_types_featured.scss */
+    /* line 268, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text > div,
     .paragraphs-item-p-featured div.group-overlay-text > h2 {
       display: table-cell;
       float: left;
       vertical-align: middle;
       width: 100%; }
-    /* line 277, ../scss/stanford_bean_types_featured.scss */
+    /* line 276, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 {
       color: #ffffff;
       font-size: 32px;
       line-height: 1.1em;
       margin: 10px 0 0; }
       @media (max-width: 580px) {
-        /* line 277, ../scss/stanford_bean_types_featured.scss */
+        /* line 276, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 {
           font-size: 24px; } }
-      /* line 288, ../scss/stanford_bean_types_featured.scss */
+      /* line 287, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 a {
         background-color: transparent;
         box-shadow: none;
@@ -238,68 +236,68 @@ div[class*="featured"] .entity-paragraphs-item {
         padding: 0;
         -webkit-text-decoration-color: #00ece9;
         text-decoration-color: #00ece9; }
-        /* line 297, ../scss/stanford_bean_types_featured.scss */
+        /* line 296, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 a:after {
           content: ''; }
-        /* line 301, ../scss/stanford_bean_types_featured.scss */
+        /* line 300, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 a:hover {
           -webkit-text-decoration-color: #ffffff;
           text-decoration-color: #ffffff; }
-    /* line 308, ../scss/stanford_bean_types_featured.scss */
+    /* line 307, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
       font-size: 20px;
       font-weight: 600;
       letter-spacing: 0; }
-      /* line 313, ../scss/stanford_bean_types_featured.scss */
+      /* line 312, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead a {
         color: #ffbd54;
         text-decoration: none;
         -webkit-text-decoration-color: #ffbd54;
         text-decoration-color: #ffbd54; }
-        /* line 319, ../scss/stanford_bean_types_featured.scss */
+        /* line 318, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead a:hover {
           color: #ffffff;
           text-decoration: underline;
           -webkit-text-decoration-color: #ffffff;
           text-decoration-color: #ffffff; }
-    /* line 328, ../scss/stanford_bean_types_featured.scss */
+    /* line 327, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
       font-size: 18px;
       line-height: 1.2em;
       margin: 20px 0 0; }
       @media (max-width: 767px) {
-        /* line 328, ../scss/stanford_bean_types_featured.scss */
+        /* line 327, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
           margin: 20px 0; } }
-      /* line 338, ../scss/stanford_bean_types_featured.scss */
+      /* line 337, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
         line-height: 1.3em;
         margin: 0 10%; }
-    /* line 344, ../scss/stanford_bean_types_featured.scss */
+    /* line 343, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link {
       margin-top: 30px; }
       @media (max-width: 979px) {
-        /* line 344, ../scss/stanford_bean_types_featured.scss */
+        /* line 343, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link {
           margin-bottom: 30px; } }
-      /* line 352, ../scss/stanford_bean_types_featured.scss */
+      /* line 351, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a {
         color: #ffffff;
         text-decoration: underline;
         -webkit-text-decoration-color: #ff525c;
         text-decoration-color: #ff525c; }
-        /* line 358, ../scss/stanford_bean_types_featured.scss */
+        /* line 357, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a:hover {
           -webkit-text-decoration-color: #ffffff;
           text-decoration-color: #ffffff; }
-        /* line 363, ../scss/stanford_bean_types_featured.scss */
+        /* line 362, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a:after {
           content: ' ›'; }
         @media (max-width: 979px) {
-          /* line 352, ../scss/stanford_bean_types_featured.scss */
+          /* line 351, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a {
             color: #333333; } }
-    /* line 374, ../scss/stanford_bean_types_featured.scss */
+    /* line 373, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
     .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
     .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise {
@@ -317,18 +315,18 @@ div[class*="featured"] .entity-paragraphs-item {
       padding: 0.8em 1.2em 0.9em;
       text-align: center;
       text-decoration: none; }
-      /* line 392, ../scss/stanford_bean_types_featured.scss */
+      /* line 391, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text a.btn-orange:after,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-pink:after,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise:after {
         content: ''; }
-      /* line 396, ../scss/stanford_bean_types_featured.scss */
+      /* line 395, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text a.btn-orange:hover,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-pink:hover,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise:hover {
         background: #333333;
         color: #fff; }
-    /* line 402, ../scss/stanford_bean_types_featured.scss */
+    /* line 401, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text a.btn {
       -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
       -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
@@ -343,158 +341,158 @@ div[class*="featured"] .entity-paragraphs-item {
       padding: 0.8em 1.2em 0.9em;
       text-align: center;
       text-decoration: none; }
-      /* line 417, ../scss/stanford_bean_types_featured.scss */
+      /* line 416, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text a.btn:after {
         content: ''; }
 
-/* line 427, ../scss/stanford_bean_types_featured.scss */
+/* line 426, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
   font-size: 22px; }
   @media (max-width: 979px) {
-    /* line 427, ../scss/stanford_bean_types_featured.scss */
+    /* line 426, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
       font-size: 18px; } }
 
-/* line 441, ../scss/stanford_bean_types_featured.scss */
+/* line 440, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-image .field-name-field-p-featured-image {
   width: 100%; }
-/* line 445, ../scss/stanford_bean_types_featured.scss */
+/* line 444, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-image .group-overlay-text {
   margin-top: 1%;
   position: relative;
   width: 100%; }
-  /* line 450, ../scss/stanford_bean_types_featured.scss */
+  /* line 449, ../scss/stanford_bean_types_featured.scss */
   .span6 .paragraphs-item-p-featured.has-image .group-overlay-text .field-name-field-p-featured-superhead {
     padding-top: 40px; }
-/* line 457, ../scss/stanford_bean_types_featured.scss */
+/* line 456, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
   width: 100%; }
-/* line 461, ../scss/stanford_bean_types_featured.scss */
+/* line 460, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-video .group-overlay-text {
   margin-top: 1%;
   position: relative;
   width: 100%; }
-  /* line 466, ../scss/stanford_bean_types_featured.scss */
+  /* line 465, ../scss/stanford_bean_types_featured.scss */
   .span6 .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead {
     padding-top: 40px; }
 
-/* line 474, ../scss/stanford_bean_types_featured.scss */
+/* line 473, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured.has-image div.group-overlay-text {
   background: transparent;
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%); }
-  /* line 481, ../scss/stanford_bean_types_featured.scss */
+  /* line 480, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead {
     padding-top: 20px; }
-    /* line 484, ../scss/stanford_bean_types_featured.scss */
+    /* line 483, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a {
       color: #ffbd54;
       text-decoration: none; }
-      /* line 488, ../scss/stanford_bean_types_featured.scss */
+      /* line 487, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a:hover {
         color: #ffffff;
         text-decoration: underline; }
   @media (max-width: 979px) {
-    /* line 474, ../scss/stanford_bean_types_featured.scss */
+    /* line 473, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image div.group-overlay-text {
       left: initial;
       position: relative;
       transform: none; }
-      /* line 501, ../scss/stanford_bean_types_featured.scss */
+      /* line 500, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead {
         padding-top: 20px; }
-        /* line 504, ../scss/stanford_bean_types_featured.scss */
+        /* line 503, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a {
           color: #b1040e;
           text-decoration: none; }
-          /* line 508, ../scss/stanford_bean_types_featured.scss */
+          /* line 507, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a:hover {
             color: #333333;
             text-decoration: underline;
             -webkit-text-decoration-color: #333333;
             text-decoration-color: #333333; }
-      /* line 517, ../scss/stanford_bean_types_featured.scss */
+      /* line 516, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image div.group-overlay-text .group-headline-h2,
       .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-description {
         color: #333333; }
-        /* line 521, ../scss/stanford_bean_types_featured.scss */
+        /* line 520, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-image div.group-overlay-text .group-headline-h2 a,
         .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-description a {
           color: #333333; } }
 
-/* line 530, ../scss/stanford_bean_types_featured.scss */
+/* line 529, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured.has-image.has-video .group-overlay-text {
   background: transparent;
   left: 0;
   position: absolute;
   transform: none; }
-  /* line 536, ../scss/stanford_bean_types_featured.scss */
+  /* line 535, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead {
     padding-top: 0; }
-    /* line 539, ../scss/stanford_bean_types_featured.scss */
+    /* line 538, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a {
       text-decoration: underline;
       -webkit-text-decoration-color: #ffbd54;
       text-decoration-color: #ffbd54; }
-      /* line 544, ../scss/stanford_bean_types_featured.scss */
+      /* line 543, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a:hover {
         color: #333333;
         -webkit-text-decoration-color: #ffffff;
         text-decoration-color: #ffffff; }
   @media (max-width: 979px) {
-    /* line 530, ../scss/stanford_bean_types_featured.scss */
+    /* line 529, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text {
       margin-top: 1%;
       position: relative;
       width: auto; }
-      /* line 557, ../scss/stanford_bean_types_featured.scss */
+      /* line 556, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead {
         padding-top: 0; } }
-  /* line 562, ../scss/stanford_bean_types_featured.scss */
+  /* line 561, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .group-headline-h2,
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead,
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-description,
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-more-link {
     color: #333333; }
-    /* line 568, ../scss/stanford_bean_types_featured.scss */
+    /* line 567, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .group-headline-h2 a,
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a,
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-description a,
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-more-link a {
       color: #333333; }
-      /* line 571, ../scss/stanford_bean_types_featured.scss */
+      /* line 570, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .group-headline-h2 a.btn,
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a.btn,
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-description a.btn,
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-more-link a.btn {
         color: #fff; }
 
-/* line 579, ../scss/stanford_bean_types_featured.scss */
+/* line 578, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured.has-video {
   background: #fff; }
-  /* line 582, ../scss/stanford_bean_types_featured.scss */
+  /* line 581, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
     float: left;
     height: 400px;
     width: 100%; }
     @media (max-width: 979px) {
-      /* line 582, ../scss/stanford_bean_types_featured.scss */
+      /* line 581, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
       .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
         width: 100%; } }
-  /* line 595, ../scss/stanford_bean_types_featured.scss */
+  /* line 594, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image {
     display: block; }
-    /* line 598, ../scss/stanford_bean_types_featured.scss */
+    /* line 597, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image img {
       height: 400px; }
-  /* line 603, ../scss/stanford_bean_types_featured.scss */
+  /* line 602, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
     position: relative; }
-  /* line 607, ../scss/stanford_bean_types_featured.scss */
+  /* line 606, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .group-overlay-text {
     background: #fff;
     color: #333333;
@@ -507,54 +505,54 @@ div[class*="featured"] .entity-paragraphs-item {
     top: 4%;
     width: 27%; }
     @media (max-width: 979px) {
-      /* line 607, ../scss/stanford_bean_types_featured.scss */
+      /* line 606, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .group-overlay-text {
         float: left;
         margin-left: 0;
         padding: 6%;
         text-align: center;
         width: 88%; } }
-    /* line 628, ../scss/stanford_bean_types_featured.scss */
+    /* line 627, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .group-overlay-text .group-headline-h2,
     .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead {
       color: #333333; }
-      /* line 632, ../scss/stanford_bean_types_featured.scss */
+      /* line 631, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .group-overlay-text .group-headline-h2 a,
       .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead a {
         color: #333333; }
-    /* line 638, ../scss/stanford_bean_types_featured.scss */
+    /* line 637, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead a {
       text-decoration: underline;
       -webkit-text-decoration-color: #ffbd54;
       text-decoration-color: #ffbd54; }
-      /* line 643, ../scss/stanford_bean_types_featured.scss */
+      /* line 642, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead a:hover {
         color: #333333;
         -webkit-text-decoration-color: #ffffff;
         text-decoration-color: #ffffff; }
-    /* line 652, ../scss/stanford_bean_types_featured.scss */
+    /* line 651, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0; }
-    /* line 657, ../scss/stanford_bean_types_featured.scss */
+    /* line 656, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .group-overlay-text.has-video {
       background: #fff; }
-      /* line 660, ../scss/stanford_bean_types_featured.scss */
+      /* line 659, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-image,
       .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-video {
         float: left;
         height: 400px;
         width: 61%; }
         @media (max-width: 979px) {
-          /* line 660, ../scss/stanford_bean_types_featured.scss */
+          /* line 659, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-image,
           .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-video {
             width: 100%; } }
         @media (max-width: 767px) {
-          /* line 660, ../scss/stanford_bean_types_featured.scss */
+          /* line 659, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-image,
           .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-video {
             height: 300px; } }
-      /* line 677, ../scss/stanford_bean_types_featured.scss */
+      /* line 676, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text {
         background: #fff;
         position: absolute;
@@ -568,7 +566,7 @@ div[class*="featured"] .entity-paragraphs-item {
         top: 4%;
         width: 27%; }
         @media (max-width: 979px) {
-          /* line 677, ../scss/stanford_bean_types_featured.scss */
+          /* line 676, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text {
             float: left;
             margin-left: 0;
@@ -576,50 +574,50 @@ div[class*="featured"] .entity-paragraphs-item {
             position: relative;
             text-align: center;
             width: 88%; } }
-        /* line 700, ../scss/stanford_bean_types_featured.scss */
+        /* line 699, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-superhead {
           padding-top: 0; }
-          /* line 703, ../scss/stanford_bean_types_featured.scss */
+          /* line 702, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-superhead a {
             text-decoration: underline;
             -webkit-text-decoration-color: #ffbd54;
             text-decoration-color: #ffbd54; }
-            /* line 708, ../scss/stanford_bean_types_featured.scss */
+            /* line 707, ../scss/stanford_bean_types_featured.scss */
             .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-superhead a:hover {
               color: #333333;
               -webkit-text-decoration-color: #ffffff;
               text-decoration-color: #ffffff; }
-        /* line 716, ../scss/stanford_bean_types_featured.scss */
+        /* line 715, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2 {
           color: #000; }
-          /* line 719, ../scss/stanford_bean_types_featured.scss */
+          /* line 718, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2 a {
             color: #000; }
-        /* line 724, ../scss/stanford_bean_types_featured.scss */
+        /* line 723, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2 {
           font-size: 32px;
           margin: 30px 0 20px;
           width: 100%;
           color: #000; }
-          /* line 730, ../scss/stanford_bean_types_featured.scss */
+          /* line 729, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2 a {
             color: #000; }
           @media (max-width: 979px) {
-            /* line 724, ../scss/stanford_bean_types_featured.scss */
+            /* line 723, ../scss/stanford_bean_types_featured.scss */
             .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2 {
               font-size: 32px; } }
-        /* line 740, ../scss/stanford_bean_types_featured.scss */
+        /* line 739, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-description {
           font-size: 22px; }
           @media (max-width: 979px) {
-            /* line 740, ../scss/stanford_bean_types_featured.scss */
+            /* line 739, ../scss/stanford_bean_types_featured.scss */
             .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-description {
               font-size: 20px; } }
-        /* line 749, ../scss/stanford_bean_types_featured.scss */
+        /* line 748, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-description .field-item {
           margin: 0; }
 
-/* line 761, ../scss/stanford_bean_types_featured.scss */
+/* line 760, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .span6 .paragraphs-item-p-featured.has-video div.group-overlay-text,
 .fullwidth .span9 .paragraphs-item-p-featured.has-video div.group-overlay-text,
 .span6 .paragraphs-item-p-featured.has-video div.group-overlay-text,
@@ -630,7 +628,7 @@ div[class*="featured"] .entity-paragraphs-item {
   position: relative;
   text-align: center;
   width: auto; }
-/* line 770, ../scss/stanford_bean_types_featured.scss */
+/* line 769, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
 .fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video,
 .fullwidth .span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
@@ -643,7 +641,7 @@ div[class*="featured"] .entity-paragraphs-item {
   height: 400px;
   width: 100%; }
   @media (max-width: 767px) {
-    /* line 770, ../scss/stanford_bean_types_featured.scss */
+    /* line 769, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
     .fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video,
     .fullwidth .span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
@@ -654,15 +652,15 @@ div[class*="featured"] .entity-paragraphs-item {
     .span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
       height: 300px; } }
 
-/* line 784, ../scss/stanford_bean_types_featured.scss */
+/* line 783, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured div.group-overlay-text {
   max-height: 100%; }
   @media (max-width: 979px) {
-    /* line 784, ../scss/stanford_bean_types_featured.scss */
+    /* line 783, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured div.group-overlay-text {
       padding: 20px 20px 24px;
       width: auto; } }
-  /* line 793, ../scss/stanford_bean_types_featured.scss */
+  /* line 792, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn,
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
@@ -670,78 +668,78 @@ div[class*="featured"] .entity-paragraphs-item {
     margin-top: 22px;
     padding: 0.8em calc(6% - 40px); }
     @media (max-width: 979px) {
-      /* line 793, ../scss/stanford_bean_types_featured.scss */
+      /* line 792, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise {
         margin: 10px 0;
         padding: 0.8em 1.2em 0.9em; } }
-  /* line 807, ../scss/stanford_bean_types_featured.scss */
+  /* line 806, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
     font-size: 22px; }
     @media (max-width: 979px) {
-      /* line 807, ../scss/stanford_bean_types_featured.scss */
+      /* line 806, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
         font-size: 16px;
         margin: 10px 0 0; } }
-    /* line 816, ../scss/stanford_bean_types_featured.scss */
+    /* line 815, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0 22%; }
       @media (max-width: 979px) {
-        /* line 816, ../scss/stanford_bean_types_featured.scss */
+        /* line 815, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
           padding-bottom: 0; } }
       @media (max-width: 580px) {
-        /* line 816, ../scss/stanford_bean_types_featured.scss */
+        /* line 815, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
           margin: 0 10%;
           padding-bottom: 30px; } }
-/* line 834, ../scss/stanford_bean_types_featured.scss */
+/* line 833, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
   font-size: 52px;
   margin: 10px 10%;
   width: 80%; }
   @media (max-width: 979px) {
-    /* line 834, ../scss/stanford_bean_types_featured.scss */
+    /* line 833, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 32px; } }
   @media (max-width: 580px) {
-    /* line 834, ../scss/stanford_bean_types_featured.scss */
+    /* line 833, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 26px;
       margin: 10px 0;
       width: 100%; } }
-/* line 852, ../scss/stanford_bean_types_featured.scss */
+/* line 851, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-description {
   font-size: 22px; }
   @media (max-width: 979px) {
-    /* line 852, ../scss/stanford_bean_types_featured.scss */
+    /* line 851, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-description {
       font-size: 20px; } }
-/* line 861, ../scss/stanford_bean_types_featured.scss */
+/* line 860, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-more-link {
   margin-top: 0; }
-/* line 866, ../scss/stanford_bean_types_featured.scss */
+/* line 865, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-video {
   background: #fff; }
-  /* line 869, ../scss/stanford_bean_types_featured.scss */
+  /* line 868, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
   .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
     float: left;
     height: 400px;
     width: 61%; }
     @media (max-width: 979px) {
-      /* line 869, ../scss/stanford_bean_types_featured.scss */
+      /* line 868, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
       .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
         width: 100%; } }
     @media (max-width: 767px) {
-      /* line 869, ../scss/stanford_bean_types_featured.scss */
+      /* line 868, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
       .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
         height: 300px; } }
-  /* line 886, ../scss/stanford_bean_types_featured.scss */
+  /* line 885, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text {
     background: #fff;
     position: absolute;
@@ -755,7 +753,7 @@ div[class*="featured"] .entity-paragraphs-item {
     top: 4%;
     width: 27%; }
     @media (max-width: 979px) {
-      /* line 886, ../scss/stanford_bean_types_featured.scss */
+      /* line 885, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text {
         float: left;
         margin-left: 0;
@@ -763,43 +761,43 @@ div[class*="featured"] .entity-paragraphs-item {
         position: relative;
         text-align: center;
         width: 88%; } }
-    /* line 909, ../scss/stanford_bean_types_featured.scss */
+    /* line 908, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2,
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-superhead {
       color: #000; }
-      /* line 913, ../scss/stanford_bean_types_featured.scss */
+      /* line 912, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 a,
       .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-superhead a {
         color: #000; }
-    /* line 918, ../scss/stanford_bean_types_featured.scss */
+    /* line 917, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
       font-size: 32px;
       margin: 25px 0 20px;
       width: 100%; }
       @media (max-width: 979px) {
-        /* line 918, ../scss/stanford_bean_types_featured.scss */
+        /* line 917, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
           font-size: 32px; } }
-      /* line 928, ../scss/stanford_bean_types_featured.scss */
+      /* line 927, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 a {
         font-size: 30px; }
-    /* line 933, ../scss/stanford_bean_types_featured.scss */
+    /* line 932, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
       font-size: 20px;
       margin: 10px 0 0; }
       @media (max-width: 1200px) {
-        /* line 933, ../scss/stanford_bean_types_featured.scss */
+        /* line 932, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
           font-size: 18px; } }
       @media (max-width: 979px) {
-        /* line 933, ../scss/stanford_bean_types_featured.scss */
+        /* line 932, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
           font-size: 20px; } }
-    /* line 948, ../scss/stanford_bean_types_featured.scss */
+    /* line 947, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0; }
 
-/* line 955, ../scss/stanford_bean_types_featured.scss */
+/* line 954, ../scss/stanford_bean_types_featured.scss */
 .entity-paragraphs-item iframe[src*="youtube"],
 .entity-paragraphs-item iframe[src*="vimeo"] {
   height: 400px; }

--- a/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
+++ b/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
@@ -149,13 +149,13 @@ div[class*="featured"] .entity-paragraphs-item {
 @media (max-width: 979px) {
   /* line 192, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured > .content .field-name-field-p-featured-image img {
-    max-height: 250px;
+    max-height: 400px;
     min-height: 200px; } }
 @media (max-width: 767px) {
   /* line 192, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured > .content .field-name-field-p-featured-image img {
-    max-height: 150px;
-    min-height: 100px; } }
+    max-height: 300px;
+    min-height: 200px; } }
 
 @media (max-width: 979px) {
   /* line 206, ../scss/stanford_bean_types_featured.scss */
@@ -522,33 +522,39 @@ div[class*="featured"] .entity-paragraphs-item {
       .paragraphs-item-p-featured.has-video .group-overlay-text .group-headline-h2 a,
       .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead a {
         color: #333333; }
-    /* line 637, ../scss/stanford_bean_types_featured.scss */
-    .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead a:hover {
+    /* line 638, ../scss/stanford_bean_types_featured.scss */
+    .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead a {
       text-decoration: underline;
-      color: #333333; }
-    /* line 643, ../scss/stanford_bean_types_featured.scss */
+      -webkit-text-decoration-color: #ffbd54;
+      text-decoration-color: #ffbd54; }
+      /* line 643, ../scss/stanford_bean_types_featured.scss */
+      .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead a:hover {
+        color: #333333;
+        -webkit-text-decoration-color: #ffffff;
+        text-decoration-color: #ffffff; }
+    /* line 652, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0; }
-    /* line 648, ../scss/stanford_bean_types_featured.scss */
+    /* line 657, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .group-overlay-text.has-video {
       background: #fff; }
-      /* line 651, ../scss/stanford_bean_types_featured.scss */
+      /* line 660, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-image,
       .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-video {
         float: left;
         height: 400px;
         width: 61%; }
         @media (max-width: 979px) {
-          /* line 651, ../scss/stanford_bean_types_featured.scss */
+          /* line 660, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-image,
           .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-video {
             width: 100%; } }
         @media (max-width: 767px) {
-          /* line 651, ../scss/stanford_bean_types_featured.scss */
+          /* line 660, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-image,
           .paragraphs-item-p-featured.has-video .group-overlay-text.has-video .field-name-field-p-featured-video {
             height: 300px; } }
-      /* line 668, ../scss/stanford_bean_types_featured.scss */
+      /* line 677, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text {
         background: #fff;
         position: absolute;
@@ -562,7 +568,7 @@ div[class*="featured"] .entity-paragraphs-item {
         top: 4%;
         width: 27%; }
         @media (max-width: 979px) {
-          /* line 668, ../scss/stanford_bean_types_featured.scss */
+          /* line 677, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text {
             float: left;
             margin-left: 0;
@@ -570,35 +576,50 @@ div[class*="featured"] .entity-paragraphs-item {
             position: relative;
             text-align: center;
             width: 88%; } }
-        /* line 691, ../scss/stanford_bean_types_featured.scss */
-        .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2,
-        .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-superhead {
-          color: #000; }
-          /* line 695, ../scss/stanford_bean_types_featured.scss */
-          .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2 a,
-          .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-superhead a {
-            color: #000; }
         /* line 700, ../scss/stanford_bean_types_featured.scss */
+        .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-superhead {
+          padding-top: 0; }
+          /* line 703, ../scss/stanford_bean_types_featured.scss */
+          .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-superhead a {
+            text-decoration: underline;
+            -webkit-text-decoration-color: #ffbd54;
+            text-decoration-color: #ffbd54; }
+            /* line 708, ../scss/stanford_bean_types_featured.scss */
+            .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-superhead a:hover {
+              color: #333333;
+              -webkit-text-decoration-color: #ffffff;
+              text-decoration-color: #ffffff; }
+        /* line 716, ../scss/stanford_bean_types_featured.scss */
+        .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2 {
+          color: #000; }
+          /* line 719, ../scss/stanford_bean_types_featured.scss */
+          .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2 a {
+            color: #000; }
+        /* line 724, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2 {
           font-size: 32px;
           margin: 30px 0 20px;
-          width: 100%; }
+          width: 100%;
+          color: #000; }
+          /* line 730, ../scss/stanford_bean_types_featured.scss */
+          .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2 a {
+            color: #000; }
           @media (max-width: 979px) {
-            /* line 700, ../scss/stanford_bean_types_featured.scss */
+            /* line 724, ../scss/stanford_bean_types_featured.scss */
             .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .group-headline-h2 {
               font-size: 32px; } }
-        /* line 711, ../scss/stanford_bean_types_featured.scss */
+        /* line 740, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-description {
           font-size: 22px; }
           @media (max-width: 979px) {
-            /* line 711, ../scss/stanford_bean_types_featured.scss */
+            /* line 740, ../scss/stanford_bean_types_featured.scss */
             .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-description {
               font-size: 20px; } }
-        /* line 720, ../scss/stanford_bean_types_featured.scss */
+        /* line 749, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text .field-name-field-p-featured-description .field-item {
           margin: 0; }
 
-/* line 732, ../scss/stanford_bean_types_featured.scss */
+/* line 761, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .span6 .paragraphs-item-p-featured.has-video div.group-overlay-text,
 .fullwidth .span9 .paragraphs-item-p-featured.has-video div.group-overlay-text,
 .span6 .paragraphs-item-p-featured.has-video div.group-overlay-text,
@@ -609,7 +630,7 @@ div[class*="featured"] .entity-paragraphs-item {
   position: relative;
   text-align: center;
   width: auto; }
-/* line 741, ../scss/stanford_bean_types_featured.scss */
+/* line 770, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
 .fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video,
 .fullwidth .span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
@@ -622,7 +643,7 @@ div[class*="featured"] .entity-paragraphs-item {
   height: 400px;
   width: 100%; }
   @media (max-width: 767px) {
-    /* line 741, ../scss/stanford_bean_types_featured.scss */
+    /* line 770, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
     .fullwidth .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video,
     .fullwidth .span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
@@ -633,15 +654,15 @@ div[class*="featured"] .entity-paragraphs-item {
     .span9 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
       height: 300px; } }
 
-/* line 755, ../scss/stanford_bean_types_featured.scss */
+/* line 784, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured div.group-overlay-text {
   max-height: 100%; }
   @media (max-width: 979px) {
-    /* line 755, ../scss/stanford_bean_types_featured.scss */
+    /* line 784, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured div.group-overlay-text {
       padding: 20px 20px 24px;
       width: auto; } }
-  /* line 764, ../scss/stanford_bean_types_featured.scss */
+  /* line 793, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn,
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
@@ -649,78 +670,78 @@ div[class*="featured"] .entity-paragraphs-item {
     margin-top: 22px;
     padding: 0.8em calc(6% - 40px); }
     @media (max-width: 979px) {
-      /* line 764, ../scss/stanford_bean_types_featured.scss */
+      /* line 793, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise {
         margin: 10px 0 10px;
         padding: 0.8em 1.2em 0.9em; } }
-  /* line 778, ../scss/stanford_bean_types_featured.scss */
+  /* line 807, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
     font-size: 22px; }
     @media (max-width: 979px) {
-      /* line 778, ../scss/stanford_bean_types_featured.scss */
+      /* line 807, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
         font-size: 16px;
         margin: 10px 0 0; } }
-    /* line 787, ../scss/stanford_bean_types_featured.scss */
+    /* line 816, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0 22%; }
       @media (max-width: 979px) {
-        /* line 787, ../scss/stanford_bean_types_featured.scss */
+        /* line 816, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
           padding-bottom: 0; } }
       @media (max-width: 580px) {
-        /* line 787, ../scss/stanford_bean_types_featured.scss */
+        /* line 816, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
           margin: 0 10%;
           padding-bottom: 30px; } }
-/* line 805, ../scss/stanford_bean_types_featured.scss */
+/* line 834, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
   font-size: 52px;
   margin: 10px 10%;
   width: 80%; }
   @media (max-width: 979px) {
-    /* line 805, ../scss/stanford_bean_types_featured.scss */
+    /* line 834, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 32px; } }
   @media (max-width: 580px) {
-    /* line 805, ../scss/stanford_bean_types_featured.scss */
+    /* line 834, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 26px;
       margin: 10px 0;
       width: 100%; } }
-/* line 823, ../scss/stanford_bean_types_featured.scss */
+/* line 852, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-description {
   font-size: 22px; }
   @media (max-width: 979px) {
-    /* line 823, ../scss/stanford_bean_types_featured.scss */
+    /* line 852, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-description {
       font-size: 20px; } }
-/* line 832, ../scss/stanford_bean_types_featured.scss */
+/* line 861, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-more-link {
   margin-top: 0; }
-/* line 837, ../scss/stanford_bean_types_featured.scss */
+/* line 866, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-video {
   background: #fff; }
-  /* line 840, ../scss/stanford_bean_types_featured.scss */
+  /* line 869, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
   .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
     float: left;
     height: 400px;
     width: 61%; }
     @media (max-width: 979px) {
-      /* line 840, ../scss/stanford_bean_types_featured.scss */
+      /* line 869, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
       .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
         width: 100%; } }
     @media (max-width: 767px) {
-      /* line 840, ../scss/stanford_bean_types_featured.scss */
+      /* line 869, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
       .fullwidth .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
         height: 300px; } }
-  /* line 857, ../scss/stanford_bean_types_featured.scss */
+  /* line 886, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text {
     position: absolute;
     padding: 3% 3% 0;
@@ -735,7 +756,7 @@ div[class*="featured"] .entity-paragraphs-item {
     top: 4%;
     width: 27%; }
     @media (max-width: 979px) {
-      /* line 857, ../scss/stanford_bean_types_featured.scss */
+      /* line 886, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text {
         float: left;
         margin-left: 0;
@@ -743,35 +764,35 @@ div[class*="featured"] .entity-paragraphs-item {
         position: relative;
         text-align: center;
         width: 88%; } }
-    /* line 880, ../scss/stanford_bean_types_featured.scss */
+    /* line 909, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2,
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-superhead {
       color: #000; }
-      /* line 884, ../scss/stanford_bean_types_featured.scss */
+      /* line 913, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 a,
       .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-superhead a {
         color: #000; }
-    /* line 889, ../scss/stanford_bean_types_featured.scss */
+    /* line 918, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
       font-size: 32px;
       margin: 30px 0 20px;
       width: 100%; }
       @media (max-width: 979px) {
-        /* line 889, ../scss/stanford_bean_types_featured.scss */
+        /* line 918, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
           font-size: 32px; } }
-    /* line 900, ../scss/stanford_bean_types_featured.scss */
+    /* line 929, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
       font-size: 22px; }
       @media (max-width: 979px) {
-        /* line 900, ../scss/stanford_bean_types_featured.scss */
+        /* line 929, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
           font-size: 20px; } }
-    /* line 909, ../scss/stanford_bean_types_featured.scss */
+    /* line 938, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0; }
 
-/* line 916, ../scss/stanford_bean_types_featured.scss */
+/* line 945, ../scss/stanford_bean_types_featured.scss */
 .entity-paragraphs-item iframe[src*="youtube"],
 .entity-paragraphs-item iframe[src*="vimeo"] {
   height: 400px; }

--- a/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
+++ b/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
@@ -743,9 +743,8 @@ div[class*="featured"] .entity-paragraphs-item {
         height: 300px; } }
   /* line 886, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text {
-    position: absolute;
-    padding: 3% 3% 0;
     background: #fff;
+    position: absolute;
     color: #000;
     display: block;
     float: right;

--- a/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
+++ b/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
@@ -774,24 +774,32 @@ div[class*="featured"] .entity-paragraphs-item {
     /* line 918, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
       font-size: 32px;
-      margin: 30px 0 20px;
+      margin: 25px 0 20px;
       width: 100%; }
       @media (max-width: 979px) {
         /* line 918, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
           font-size: 32px; } }
-    /* line 929, ../scss/stanford_bean_types_featured.scss */
+      /* line 928, ../scss/stanford_bean_types_featured.scss */
+      .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 a {
+        font-size: 30px; }
+    /* line 933, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
-      font-size: 22px; }
+      font-size: 20px;
+      margin: 10px 0 0; }
+      @media (max-width: 1200px) {
+        /* line 933, ../scss/stanford_bean_types_featured.scss */
+        .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
+          font-size: 18px; } }
       @media (max-width: 979px) {
-        /* line 929, ../scss/stanford_bean_types_featured.scss */
+        /* line 933, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
           font-size: 20px; } }
-    /* line 938, ../scss/stanford_bean_types_featured.scss */
+    /* line 948, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0; }
 
-/* line 945, ../scss/stanford_bean_types_featured.scss */
+/* line 955, ../scss/stanford_bean_types_featured.scss */
 .entity-paragraphs-item iframe[src*="youtube"],
 .entity-paragraphs-item iframe[src*="vimeo"] {
   height: 400px; }

--- a/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
+++ b/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
@@ -550,9 +550,8 @@ div[class*="featured"] .entity-paragraphs-item {
             height: 300px; } }
       /* line 668, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .group-overlay-text.has-video div.group-overlay-text {
-        position: absolute;
-        padding: 3% 3% 0;
         background: #fff;
+        position: absolute;
         color: #000;
         display: block;
         float: right;

--- a/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
+++ b/modules/stanford_bean_types_featured/css/stanford_bean_types_featured.css
@@ -37,54 +37,133 @@ div[class*="featured"] .entity-paragraphs-item {
     margin-right: 0; }
 
 /* line 47, ../scss/stanford_bean_types_featured.scss */
+.row-fluid .block-bean.well.featured-block {
+  margin-bottom: 0; }
+
+/* line 51, ../scss/stanford_bean_types_featured.scss */
 .span6 .featured-block {
   margin-left: 0;
   margin-right: 0; }
 
-/* line 52, ../scss/stanford_bean_types_featured.scss */
+/* line 60, ../scss/stanford_bean_types_featured.scss */
+.front .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
+  margin-top: .2em;
+  margin-bottom: 20px; }
+
+/* line 72, ../scss/stanford_bean_types_featured.scss */
+.front .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
+  margin: 0 28%; }
+  @media (max-width: 979px) {
+    /* line 72, ../scss/stanford_bean_types_featured.scss */
+    .front .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
+      margin: 0 22%; } }
+
+/* line 88, ../scss/stanford_bean_types_featured.scss */
+.front .span9 .paragraphs-item-p-featured.has-image .group-headline-h2,
+.span9 .paragraphs-item-p-featured.has-image .group-headline-h2 {
+  font-size: 42px;
+  margin-top: .2em;
+  margin-bottom: 20px; }
+  @media (max-width: 1199px) {
+    /* line 88, ../scss/stanford_bean_types_featured.scss */
+    .front .span9 .paragraphs-item-p-featured.has-image .group-headline-h2,
+    .span9 .paragraphs-item-p-featured.has-image .group-headline-h2 {
+      font-size: 36px; } }
+  @media (max-width: 979px) {
+    /* line 88, ../scss/stanford_bean_types_featured.scss */
+    .front .span9 .paragraphs-item-p-featured.has-image .group-headline-h2,
+    .span9 .paragraphs-item-p-featured.has-image .group-headline-h2 {
+      font-size: 32px; } }
+  @media (max-width: 767px) {
+    /* line 88, ../scss/stanford_bean_types_featured.scss */
+    .front .span9 .paragraphs-item-p-featured.has-image .group-headline-h2,
+    .span9 .paragraphs-item-p-featured.has-image .group-headline-h2 {
+      font-size: 28px; } }
+/* line 112, ../scss/stanford_bean_types_featured.scss */
+.front .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item,
+.span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
+  font-size: 22px;
+  margin: 0 15%; }
+  @media (max-width: 1199px) {
+    /* line 112, ../scss/stanford_bean_types_featured.scss */
+    .front .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item,
+    .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
+      font-size: 20px; } }
+  @media (max-width: 979px) {
+    /* line 112, ../scss/stanford_bean_types_featured.scss */
+    .front .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item,
+    .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
+      font-size: 18px; } }
+  @media (max-width: 767px) {
+    /* line 112, ../scss/stanford_bean_types_featured.scss */
+    .front .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item,
+    .span9 .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
+      margin: 0 8%; } }
+
+/* line 139, ../scss/stanford_bean_types_featured.scss */
+.front .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead,
+.span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
+  font-size: 20px; }
+  @media (max-width: 1199px) {
+    /* line 139, ../scss/stanford_bean_types_featured.scss */
+    .front .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead,
+    .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
+      font-size: 18px; } }
+
+/* line 150, ../scss/stanford_bean_types_featured.scss */
 .front .block-bean.no-padding.well.featured-block {
   display: inline-block;
   margin: 0;
   width: 100%; }
-  /* line 57, ../scss/stanford_bean_types_featured.scss */
+  /* line 155, ../scss/stanford_bean_types_featured.scss */
   .front .block-bean.no-padding.well.featured-block.top-margin {
     margin-top: 100px; }
-  /* line 61, ../scss/stanford_bean_types_featured.scss */
+  /* line 159, ../scss/stanford_bean_types_featured.scss */
   .front .block-bean.no-padding.well.featured-block.bottom-margin {
     margin-bottom: 100px; }
-  /* line 65, ../scss/stanford_bean_types_featured.scss */
+  /* line 163, ../scss/stanford_bean_types_featured.scss */
   .front .block-bean.no-padding.well.featured-block.span9 {
-    width: 74.5%;
-    margin-left: 12.75%;
-    margin-right: 12.75%; }
+    width: 62.5%;
+    margin-left: 18.75%;
+    margin-right: 18.75%; }
+  /* line 169, ../scss/stanford_bean_types_featured.scss */
+  .front .block-bean.no-padding.well.featured-block.span6 {
+    width: 46.5%;
+    margin-left: 26.75%;
+    margin-right: 26.75%; }
 
-/* line 72, ../scss/stanford_bean_types_featured.scss */
+@media (max-width: 979px) {
+  /* line 178, ../scss/stanford_bean_types_featured.scss */
+  .paragraphs-item-p-featured > .content .field-name-field-p-featured-image img {
+    max-height: 250px;
+    min-height: 200px; } }
+/* line 184, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured {
   margin-bottom: 0; }
-  /* line 75, ../scss/stanford_bean_types_featured.scss */
+  /* line 187, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured a.play-video {
     color: #ffffff;
     display: block;
     font-size: 0;
     z-index: 3; }
-  /* line 82, ../scss/stanford_bean_types_featured.scss */
+  /* line 194, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured .field-name-field-p-featured-image {
     background: #001933;
     position: relative;
     z-index: 2; }
-    /* line 87, ../scss/stanford_bean_types_featured.scss */
+    /* line 199, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured .field-name-field-p-featured-image img {
       height: auto;
       opacity: .3;
       width: 100%; }
-  /* line 94, ../scss/stanford_bean_types_featured.scss */
+  /* line 206, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured .field-name-field-p-featured-video {
     height: auto;
     position: absolute;
     width: 100%;
     top: -20px;
     z-index: 1; }
-  /* line 102, ../scss/stanford_bean_types_featured.scss */
+  /* line 214, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured div.group-overlay-text {
     background-color: transparent;
     color: #fff;
@@ -98,28 +177,28 @@ div[class*="featured"] .entity-paragraphs-item {
     width: 100%;
     z-index: 2; }
     @media (max-width: 979px) {
-      /* line 102, ../scss/stanford_bean_types_featured.scss */
+      /* line 214, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text {
         position: relative;
         width: 100%; } }
-    /* line 121, ../scss/stanford_bean_types_featured.scss */
+    /* line 233, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text > div,
     .paragraphs-item-p-featured div.group-overlay-text > h2 {
       display: table-cell;
       float: left;
       vertical-align: middle;
       width: 100%; }
-    /* line 129, ../scss/stanford_bean_types_featured.scss */
+    /* line 241, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 {
       color: #ffffff;
       font-size: 32px;
       line-height: 1.1em;
       margin: 10px 0 0; }
       @media (max-width: 580px) {
-        /* line 129, ../scss/stanford_bean_types_featured.scss */
+        /* line 241, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 {
           font-size: 24px; } }
-      /* line 140, ../scss/stanford_bean_types_featured.scss */
+      /* line 252, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 a {
         background-color: transparent;
         box-shadow: none;
@@ -128,64 +207,68 @@ div[class*="featured"] .entity-paragraphs-item {
         padding: 0;
         -webkit-text-decoration-color: #00ece9;
         text-decoration-color: #00ece9; }
-        /* line 149, ../scss/stanford_bean_types_featured.scss */
+        /* line 261, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 a:after {
           content: ''; }
-        /* line 153, ../scss/stanford_bean_types_featured.scss */
+        /* line 265, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .group-headline-h2 a:hover {
           -webkit-text-decoration-color: #ffffff;
           text-decoration-color: #ffffff; }
-    /* line 160, ../scss/stanford_bean_types_featured.scss */
+    /* line 272, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
       font-size: 20px;
-      font-weight: 600; }
-      /* line 164, ../scss/stanford_bean_types_featured.scss */
+      font-weight: 600;
+      letter-spacing: 0; }
+      /* line 277, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead a {
-        color: #fff;
-        text-decoration: underline;
+        color: #ffbd54;
+        text-decoration: none;
         -webkit-text-decoration-color: #ffbd54;
         text-decoration-color: #ffbd54; }
-        /* line 170, ../scss/stanford_bean_types_featured.scss */
+        /* line 283, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead a:hover {
+          color: #ffffff;
+          text-decoration: underline;
           -webkit-text-decoration-color: #ffffff;
           text-decoration-color: #ffffff; }
-    /* line 177, ../scss/stanford_bean_types_featured.scss */
+    /* line 292, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
       font-size: 18px;
       line-height: 1.2em;
-      margin: 30px 0 0; }
+      margin: 20px 0 0; }
       @media (max-width: 767px) {
-        /* line 177, ../scss/stanford_bean_types_featured.scss */
+        /* line 292, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
           margin: 20px 0; } }
-      /* line 187, ../scss/stanford_bean_types_featured.scss */
+      /* line 302, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
+        line-height: 1.3em;
         margin: 0 10%; }
-    /* line 192, ../scss/stanford_bean_types_featured.scss */
+    /* line 308, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link {
       margin-top: 30px; }
       @media (max-width: 979px) {
-        /* line 192, ../scss/stanford_bean_types_featured.scss */
+        /* line 308, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link {
           margin-bottom: 30px; } }
-      /* line 199, ../scss/stanford_bean_types_featured.scss */
+      /* line 316, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a {
         color: #ffffff;
         text-decoration: underline;
         -webkit-text-decoration-color: #ff525c;
         text-decoration-color: #ff525c; }
-        /* line 205, ../scss/stanford_bean_types_featured.scss */
+        /* line 322, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a:hover {
           -webkit-text-decoration-color: #ffffff;
           text-decoration-color: #ffffff; }
-        /* line 210, ../scss/stanford_bean_types_featured.scss */
+        /* line 327, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a:after {
           content: ' ›'; }
         @media (max-width: 979px) {
-          /* line 199, ../scss/stanford_bean_types_featured.scss */
+          /* line 316, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-more-link a {
             color: #333333; } }
-    /* line 220, ../scss/stanford_bean_types_featured.scss */
+    /* line 338, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
     .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
     .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise {
@@ -203,18 +286,18 @@ div[class*="featured"] .entity-paragraphs-item {
       padding: 0.8em 1.2em 0.9em;
       text-align: center;
       text-decoration: none; }
-      /* line 238, ../scss/stanford_bean_types_featured.scss */
+      /* line 356, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text a.btn-orange:after,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-pink:after,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise:after {
         content: ''; }
-      /* line 242, ../scss/stanford_bean_types_featured.scss */
+      /* line 360, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text a.btn-orange:hover,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-pink:hover,
       .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise:hover {
         background: #333333;
         color: #fff; }
-    /* line 248, ../scss/stanford_bean_types_featured.scss */
+    /* line 366, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured div.group-overlay-text a.btn {
       -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
       -moz-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
@@ -229,159 +312,165 @@ div[class*="featured"] .entity-paragraphs-item {
       padding: 0.8em 1.2em 0.9em;
       text-align: center;
       text-decoration: none; }
-      /* line 263, ../scss/stanford_bean_types_featured.scss */
+      /* line 381, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured div.group-overlay-text a.btn:after {
         content: ''; }
 
-/* line 272, ../scss/stanford_bean_types_featured.scss */
+/* line 391, ../scss/stanford_bean_types_featured.scss */
+.paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
+  font-size: 22px; }
+  @media (max-width: 979px) {
+    /* line 391, ../scss/stanford_bean_types_featured.scss */
+    .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-superhead {
+      font-size: 18px; } }
+
+/* line 405, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-image .field-name-field-p-featured-image {
   width: 100%; }
-/* line 276, ../scss/stanford_bean_types_featured.scss */
+/* line 409, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-image .group-overlay-text {
   margin-top: 1%;
   position: relative;
   width: 100%; }
-  /* line 281, ../scss/stanford_bean_types_featured.scss */
+  /* line 414, ../scss/stanford_bean_types_featured.scss */
   .span6 .paragraphs-item-p-featured.has-image .group-overlay-text .field-name-field-p-featured-superhead {
     padding-top: 40px; }
-/* line 288, ../scss/stanford_bean_types_featured.scss */
+/* line 421, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
   width: 100%; }
-/* line 292, ../scss/stanford_bean_types_featured.scss */
+/* line 425, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-video .group-overlay-text {
   margin-top: 1%;
   position: relative;
   width: 100%; }
-  /* line 297, ../scss/stanford_bean_types_featured.scss */
+  /* line 430, ../scss/stanford_bean_types_featured.scss */
   .span6 .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead {
     padding-top: 40px; }
 
-/* line 305, ../scss/stanford_bean_types_featured.scss */
+/* line 438, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured.has-image div.group-overlay-text {
   background: transparent;
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%); }
-  /* line 312, ../scss/stanford_bean_types_featured.scss */
+  /* line 445, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead {
     padding-top: 20px; }
-    /* line 315, ../scss/stanford_bean_types_featured.scss */
+    /* line 448, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a {
       color: #ffbd54;
       text-decoration: none; }
-      /* line 319, ../scss/stanford_bean_types_featured.scss */
+      /* line 452, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a:hover {
         color: #ffffff;
         text-decoration: underline; }
   @media (max-width: 979px) {
-    /* line 305, ../scss/stanford_bean_types_featured.scss */
+    /* line 438, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image div.group-overlay-text {
       left: initial;
       position: relative;
       transform: none; }
-      /* line 332, ../scss/stanford_bean_types_featured.scss */
+      /* line 465, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead {
         padding-top: 20px; }
-        /* line 335, ../scss/stanford_bean_types_featured.scss */
+        /* line 468, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a {
-          text-decoration: underline;
-          -webkit-text-decoration-color: #ffbd54;
-          text-decoration-color: #ffbd54; }
-          /* line 340, ../scss/stanford_bean_types_featured.scss */
+          color: #b1040e;
+          text-decoration: none; }
+          /* line 472, ../scss/stanford_bean_types_featured.scss */
           .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a:hover {
             color: #333333;
-            -webkit-text-decoration-color: #ffffff;
-            text-decoration-color: #ffffff; }
-      /* line 348, ../scss/stanford_bean_types_featured.scss */
+            text-decoration: underline;
+            -webkit-text-decoration-color: #333333;
+            text-decoration-color: #333333; }
+      /* line 481, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image div.group-overlay-text .group-headline-h2,
-      .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead,
       .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-description {
         color: #333333; }
-        /* line 353, ../scss/stanford_bean_types_featured.scss */
+        /* line 485, ../scss/stanford_bean_types_featured.scss */
         .paragraphs-item-p-featured.has-image div.group-overlay-text .group-headline-h2 a,
-        .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-superhead a,
         .paragraphs-item-p-featured.has-image div.group-overlay-text .field-name-field-p-featured-description a {
           color: #333333; } }
 
-/* line 362, ../scss/stanford_bean_types_featured.scss */
+/* line 494, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured.has-image.has-video .group-overlay-text {
   background: transparent;
   left: 0;
   position: absolute;
   transform: none; }
-  /* line 369, ../scss/stanford_bean_types_featured.scss */
+  /* line 501, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a {
     text-decoration: underline;
     -webkit-text-decoration-color: #ffbd54;
     text-decoration-color: #ffbd54; }
-    /* line 374, ../scss/stanford_bean_types_featured.scss */
+    /* line 506, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a:hover {
       color: #333333;
       -webkit-text-decoration-color: #ffffff;
       text-decoration-color: #ffffff; }
   @media (max-width: 979px) {
-    /* line 362, ../scss/stanford_bean_types_featured.scss */
+    /* line 494, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text {
       margin-top: 1%;
       position: relative;
       width: auto; }
-      /* line 387, ../scss/stanford_bean_types_featured.scss */
+      /* line 519, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead {
         padding-top: 0; } }
-  /* line 392, ../scss/stanford_bean_types_featured.scss */
+  /* line 524, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .group-headline-h2,
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead,
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-description,
   .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-more-link {
     color: #333333; }
-    /* line 398, ../scss/stanford_bean_types_featured.scss */
+    /* line 530, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .group-headline-h2 a,
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a,
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-description a,
     .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-more-link a {
       color: #333333; }
-      /* line 401, ../scss/stanford_bean_types_featured.scss */
+      /* line 533, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .group-headline-h2 a.btn,
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-superhead a.btn,
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-description a.btn,
       .paragraphs-item-p-featured.has-image.has-video .group-overlay-text .field-name-field-p-featured-more-link a.btn {
         color: #fff; }
 
-/* line 411, ../scss/stanford_bean_types_featured.scss */
+/* line 543, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-image.has-video .field-name-field-p-featured-image,
 .span6 .paragraphs-item-p-featured.has-image.has-video .field-name-field-p-featured-video {
   width: 100%; }
-/* line 416, ../scss/stanford_bean_types_featured.scss */
+/* line 548, ../scss/stanford_bean_types_featured.scss */
 .span6 .paragraphs-item-p-featured.has-image.has-video .group-overlay-text {
   background: transparent;
   position: relative;
   width: 100%; }
 
-/* line 424, ../scss/stanford_bean_types_featured.scss */
+/* line 556, ../scss/stanford_bean_types_featured.scss */
 .paragraphs-item-p-featured.has-video {
   background: #fff; }
-  /* line 427, ../scss/stanford_bean_types_featured.scss */
+  /* line 559, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
     float: left;
     height: 400px;
     width: 61%; }
     @media (max-width: 979px) {
-      /* line 427, ../scss/stanford_bean_types_featured.scss */
+      /* line 559, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image,
       .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
         width: 100%; } }
-  /* line 440, ../scss/stanford_bean_types_featured.scss */
+  /* line 572, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image {
     display: block; }
-    /* line 443, ../scss/stanford_bean_types_featured.scss */
+    /* line 575, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .field-name-field-p-featured-image img {
       height: 400px; }
-  /* line 448, ../scss/stanford_bean_types_featured.scss */
+  /* line 580, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .field-name-field-p-featured-video {
     position: relative; }
-  /* line 452, ../scss/stanford_bean_types_featured.scss */
+  /* line 584, ../scss/stanford_bean_types_featured.scss */
   .paragraphs-item-p-featured.has-video .group-overlay-text {
     background: #fff;
     color: #333333;
@@ -394,113 +483,116 @@ div[class*="featured"] .entity-paragraphs-item {
     top: 4%;
     width: 27%; }
     @media (max-width: 979px) {
-      /* line 452, ../scss/stanford_bean_types_featured.scss */
+      /* line 584, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .group-overlay-text {
         float: left;
         margin-left: 0;
         padding: 6%;
         text-align: center;
         width: 88%; } }
-    /* line 473, ../scss/stanford_bean_types_featured.scss */
+    /* line 605, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .group-overlay-text .group-headline-h2,
     .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead {
       color: #333333; }
-      /* line 477, ../scss/stanford_bean_types_featured.scss */
+      /* line 609, ../scss/stanford_bean_types_featured.scss */
       .paragraphs-item-p-featured.has-video .group-overlay-text .group-headline-h2 a,
       .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-superhead a {
         color: #333333; }
-    /* line 483, ../scss/stanford_bean_types_featured.scss */
+    /* line 615, ../scss/stanford_bean_types_featured.scss */
     .paragraphs-item-p-featured.has-video .group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0; }
 
-/* line 491, ../scss/stanford_bean_types_featured.scss */
+/* line 623, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured div.group-overlay-text {
   max-height: 100%; }
   @media (max-width: 979px) {
-    /* line 491, ../scss/stanford_bean_types_featured.scss */
+    /* line 623, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured div.group-overlay-text {
+      padding: 20px 20px 24px;
       width: auto; } }
-  /* line 499, ../scss/stanford_bean_types_featured.scss */
+  /* line 632, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn,
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise {
-    margin-top: 42px;
+    margin-top: 22px;
     padding: 0.8em calc(6% - 40px); }
     @media (max-width: 979px) {
-      /* line 499, ../scss/stanford_bean_types_featured.scss */
+      /* line 632, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-orange,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-pink,
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text a.btn-turquoise {
+        margin: 10px 0 10px;
         padding: 0.8em 1.2em 0.9em; } }
-  /* line 512, ../scss/stanford_bean_types_featured.scss */
+  /* line 646, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
     font-size: 22px; }
     @media (max-width: 979px) {
-      /* line 512, ../scss/stanford_bean_types_featured.scss */
+      /* line 646, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description {
-        font-size: 20px; } }
-    /* line 520, ../scss/stanford_bean_types_featured.scss */
+        font-size: 16px;
+        margin: 10px 0 0; } }
+    /* line 655, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
       margin: 0 22%; }
       @media (max-width: 979px) {
-        /* line 520, ../scss/stanford_bean_types_featured.scss */
+        /* line 655, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
-          padding-bottom: 30px; } }
+          padding-bottom: 0; } }
       @media (max-width: 580px) {
-        /* line 520, ../scss/stanford_bean_types_featured.scss */
+        /* line 655, ../scss/stanford_bean_types_featured.scss */
         .fullwidth .paragraphs-item-p-featured div.group-overlay-text .field-name-field-p-featured-description .field-item {
           margin: 0 10%;
           padding-bottom: 30px; } }
-/* line 538, ../scss/stanford_bean_types_featured.scss */
+/* line 673, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
   font-size: 52px;
   margin: 10px 10%;
   width: 80%; }
   @media (max-width: 979px) {
-    /* line 538, ../scss/stanford_bean_types_featured.scss */
+    /* line 673, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 32px; } }
   @media (max-width: 580px) {
-    /* line 538, ../scss/stanford_bean_types_featured.scss */
+    /* line 673, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .group-headline-h2 {
       font-size: 26px; } }
-/* line 554, ../scss/stanford_bean_types_featured.scss */
+/* line 689, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-description {
   font-size: 22px; }
   @media (max-width: 979px) {
-    /* line 554, ../scss/stanford_bean_types_featured.scss */
+    /* line 689, ../scss/stanford_bean_types_featured.scss */
     .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-description {
       font-size: 20px; } }
-/* line 563, ../scss/stanford_bean_types_featured.scss */
+/* line 698, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-image .field-name-field-p-featured-more-link {
   margin-top: 0; }
-/* line 569, ../scss/stanford_bean_types_featured.scss */
+/* line 704, ../scss/stanford_bean_types_featured.scss */
 .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text {
   margin-top: 0;
   padding: 3% 3% 0; }
-  /* line 573, ../scss/stanford_bean_types_featured.scss */
+  /* line 708, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
     font-size: 32px;
     margin: 30px 0 0;
     width: auto; }
     @media (max-width: 979px) {
-      /* line 573, ../scss/stanford_bean_types_featured.scss */
+      /* line 708, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .group-headline-h2 {
         font-size: 32px; } }
-  /* line 584, ../scss/stanford_bean_types_featured.scss */
+  /* line 719, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
     font-size: 22px; }
     @media (max-width: 979px) {
-      /* line 584, ../scss/stanford_bean_types_featured.scss */
+      /* line 719, ../scss/stanford_bean_types_featured.scss */
       .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description {
         font-size: 20px; } }
-  /* line 593, ../scss/stanford_bean_types_featured.scss */
+  /* line 728, ../scss/stanford_bean_types_featured.scss */
   .fullwidth .paragraphs-item-p-featured.has-video div.group-overlay-text .field-name-field-p-featured-description .field-item {
     margin: 0; }
 
-/* line 600, ../scss/stanford_bean_types_featured.scss */
+/* line 735, ../scss/stanford_bean_types_featured.scss */
 .entity-paragraphs-item iframe[src*="youtube"],
 .entity-paragraphs-item iframe[src*="vimeo"] {
   height: 400px; }

--- a/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
+++ b/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
@@ -799,7 +799,7 @@ div[class*="featured"] {
 
       @media (max-width: 979px) {
 
-        margin: 10px 0 10px;
+        margin: 10px 0;
         padding: 0.8em 1.2em 0.9em;
       }
     }

--- a/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
+++ b/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
@@ -53,29 +53,27 @@ div[class*="featured"] {
           margin-bottom: 20px;
         }
       }
-    }
-  }
-}
 
-.front .fullwidth .paragraphs-item-p-featured {
-  div.group-overlay-text {
-    .field-name-field-p-featured-description {
-      .field-item {
-        margin: 0 28%;
+      div.group-overlay-text {
+        .field-name-field-p-featured-description {
+          .field-item {
+            margin: 0 28%;
 
-        @media (max-width: 979px) {
+            @media (max-width: 979px) {
 
-          margin: 0 22%;
-        }
+              margin: 0 22%;
+            }
 
-        @media (max-width: 580px) {
+            @media (max-width: 580px) {
 
-          margin: 0 12%;
-        }
+              margin: 0 12%;
+            }
 
-        @media (max-width: 480px) {
+            @media (max-width: 480px) {
 
-          margin: 0;
+              margin: 0;
+            }
+          }
         }
       }
     }
@@ -142,22 +140,23 @@ div[class*="featured"] {
       }
     }
   }
-}
 
-.front .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured,
-.span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured {
-  div.group-overlay-text {
-    .field-name-field-p-featured-superhead {
-      font-size: 20px;
+  .paragraphs-items-field-featured-block-featured-full {
+    .paragraphs-item-p-featured {
+      div.group-overlay-text {
+        .field-name-field-p-featured-superhead {
+          font-size: 20px;
 
-      @media (max-width: 1199px) {
+          @media (max-width: 1199px) {
 
-        font-size: 18px;
-      }
+            font-size: 18px;
+          }
 
-      @media (max-width: 480px) {
+          @media (max-width: 480px) {
 
-        font-size: 16px;
+            font-size: 16px;
+          }
+        }
       }
     }
   }

--- a/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
+++ b/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
@@ -44,9 +44,107 @@ div[class*="featured"] {
   }
 }
 
+.row-fluid .block-bean.well.featured-block {
+  margin-bottom: 0;
+}
+
 .span6 .featured-block {
   margin-left: 0;
   margin-right: 0;
+}
+
+.front {
+  .fullwidth {
+    .paragraphs-item-p-featured {
+      &.has-image {
+        .group-headline-h2 {
+          margin-top: .2em;
+          margin-bottom: 20px;
+        }
+      }
+    }
+  }
+}
+
+.front .fullwidth .paragraphs-item-p-featured {
+  div.group-overlay-text {
+    .field-name-field-p-featured-description {
+      .field-item {
+        margin: 0 28%;
+
+        @media (max-width: 979px) {
+
+          margin: 0 22%;
+        }
+      }
+    }
+  }
+}
+
+.front .span9,
+.span9 {
+  .paragraphs-item-p-featured {
+    &.has-image {
+      .group-headline-h2 {
+        font-size: 42px;
+        margin-top: .2em;
+        margin-bottom: 20px;
+
+        @media (max-width: 1199px) {
+
+          font-size: 36px;
+        }
+
+        @media (max-width: 979px) {
+
+          font-size: 32px;
+        }
+
+        @media (max-width: 767px) {
+
+          font-size: 28px;
+        }
+      }
+    }
+
+    div.group-overlay-text {
+      .field-name-field-p-featured-description {
+        .field-item {
+          font-size: 22px;
+          margin: 0 15%;
+
+          @media (max-width: 1199px) {
+
+            font-size: 20px;
+          }
+
+          @media (max-width: 979px) {
+
+            font-size: 18px;
+          }
+
+          @media (max-width: 767px) {
+
+            margin: 0 8%;
+          }
+        }
+      }
+    }
+  }
+}
+
+.front .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured,
+.span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured{
+  div.group-overlay-text {
+    .field-name-field-p-featured-superhead {
+      font-size: 20px;
+
+      @media (max-width: 1199px) {
+
+        font-size: 18px;
+      }
+    }
+  }
 }
 
 .front .block-bean.no-padding.well.featured-block {
@@ -63,9 +161,23 @@ div[class*="featured"] {
   }
 
   &.span9 {
-    width: 74.5%;
-    margin-left: 12.75%;
-    margin-right: 12.75%;
+    width: 62.5%;
+    margin-left: 18.75%;
+    margin-right: 18.75%;
+  }
+
+  &.span6 {
+    width: 46.5%;
+    margin-left: 26.75%;
+    margin-right: 26.75%;
+  }
+}
+
+@media (max-width: 979px) {
+
+  .paragraphs-item-p-featured > .content .field-name-field-p-featured-image img {
+    max-height: 250px;
+    min-height: 200px;
   }
 }
 
@@ -160,14 +272,17 @@ div[class*="featured"] {
     .field-name-field-p-featured-superhead {
       font-size: 20px;
       font-weight: 600;
+      letter-spacing: 0;
 
       a {
-        color: #fff;
-        text-decoration: underline;
+        color: #ffbd54;
+        text-decoration: none;
         -webkit-text-decoration-color: #ffbd54;
         text-decoration-color: #ffbd54;
 
         &:hover {
+          color: #ffffff;
+          text-decoration: underline;
           -webkit-text-decoration-color: #ffffff;
           text-decoration-color: #ffffff;
         }
@@ -177,7 +292,7 @@ div[class*="featured"] {
     .field-name-field-p-featured-description {
       font-size: 18px;
       line-height: 1.2em;
-      margin: 30px 0 0;
+      margin: 20px 0 0;
 
       @media (max-width: 767px) {
 
@@ -185,6 +300,7 @@ div[class*="featured"] {
       }
 
       .field-item {
+        line-height: 1.3em;
         margin: 0 10%;
       }
     }
@@ -193,6 +309,7 @@ div[class*="featured"] {
       margin-top: 30px;
 
       @media (max-width: 979px) {
+
         margin-bottom: 30px;
       }
 
@@ -212,6 +329,7 @@ div[class*="featured"] {
         }
 
         @media (max-width: 979px) {
+
           color: #333333;
         }
       }
@@ -262,6 +380,21 @@ div[class*="featured"] {
 
       &:after {
         content: '';
+      }
+    }
+  }
+}
+
+.paragraphs-items-field-featured-block-featured-full {
+  .paragraphs-item-p-featured {
+    div.group-overlay-text {
+      .field-name-field-p-featured-superhead {
+        font-size: 22px;
+
+        @media (max-width: 979px) {
+
+          font-size: 18px;
+        }
       }
     }
   }
@@ -333,20 +466,19 @@ div[class*="featured"] {
         padding-top: 20px;
 
         a {
-          text-decoration: underline;
-          -webkit-text-decoration-color: #ffbd54;
-          text-decoration-color: #ffbd54;
+          color: #b1040e;
+          text-decoration: none;
 
           &:hover {
             color: #333333;
-            -webkit-text-decoration-color: #ffffff;
-            text-decoration-color: #ffffff;
+            text-decoration: underline;
+            -webkit-text-decoration-color: #333333;
+            text-decoration-color: #333333;
           }
         }
       }
 
       .group-headline-h2,
-      .field-name-field-p-featured-superhead,
       .field-name-field-p-featured-description {
         color: #333333;
 
@@ -493,6 +625,7 @@ div[class*="featured"] {
 
     @media (max-width: 979px) {
 
+      padding: 20px 20px 24px;
       width: auto;
     }
 
@@ -500,11 +633,12 @@ div[class*="featured"] {
     a.btn-orange,
     a.btn-pink,
     a.btn-turquoise {
-      margin-top: 42px;
+      margin-top: 22px;
       padding: .8em calc(6% - 40px);
 
       @media (max-width: 979px) {
 
+        margin: 10px 0 10px;
         padding: 0.8em 1.2em 0.9em;
       }
     }
@@ -514,7 +648,8 @@ div[class*="featured"] {
 
       @media (max-width: 979px) {
 
-        font-size: 20px;
+        font-size: 16px;
+        margin: 10px 0 0;
       }
 
       .field-item {
@@ -522,7 +657,7 @@ div[class*="featured"] {
 
         @media (max-width: 979px) {
 
-          padding-bottom: 30px;
+          padding-bottom: 0;
         }
 
         @media (max-width: 580px) {

--- a/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
+++ b/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
@@ -917,17 +917,27 @@ div[class*="featured"] {
 
       .group-headline-h2 {
         font-size: 32px;
-        margin: 30px 0 20px;
+        margin: 25px 0 20px;
         width: 100%;
 
         @media (max-width: 979px) {
 
           font-size: 32px;
         }
+
+        a {
+          font-size: 30px;
+        }
       }
 
       .field-name-field-p-featured-description {
-        font-size: 22px;
+        font-size: 20px;
+        margin: 10px 0 0;
+
+        @media (max-width: 1200px) {
+
+          font-size: 18px;
+        }
 
         @media (max-width: 979px) {
 

--- a/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
+++ b/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
@@ -44,15 +44,6 @@ div[class*="featured"] {
   }
 }
 
-.row-fluid .block-bean.well.featured-block {
-  margin-bottom: 0;
-}
-
-.span6 .featured-block {
-  margin-left: 0;
-  margin-right: 0;
-}
-
 .front {
   .fullwidth {
     .paragraphs-item-p-featured {
@@ -75,6 +66,16 @@ div[class*="featured"] {
         @media (max-width: 979px) {
 
           margin: 0 22%;
+        }
+
+        @media (max-width: 580px) {
+
+          margin: 0 12%;
+        }
+
+        @media (max-width: 480px) {
+
+          margin: 0;
         }
       }
     }
@@ -104,6 +105,11 @@ div[class*="featured"] {
 
           font-size: 28px;
         }
+
+        @media (max-width: 480px) {
+
+          font-size: 24px;
+        }
       }
     }
 
@@ -127,6 +133,11 @@ div[class*="featured"] {
 
             margin: 0 8%;
           }
+
+          @media (max-width: 480px) {
+
+            font-size: 16px;
+          }
         }
       }
     }
@@ -142,6 +153,11 @@ div[class*="featured"] {
       @media (max-width: 1199px) {
 
         font-size: 18px;
+      }
+
+      @media (max-width: 480px) {
+
+        font-size: 16px;
       }
     }
   }
@@ -173,13 +189,20 @@ div[class*="featured"] {
   }
 }
 
-@media (max-width: 979px) {
+.paragraphs-item-p-featured > .content .field-name-field-p-featured-image img {
+  @media (max-width: 979px) {
 
-  .paragraphs-item-p-featured > .content .field-name-field-p-featured-image img {
     max-height: 250px;
     min-height: 200px;
   }
+
+  @media (max-width: 767px) {
+
+    max-height: 150px;
+    min-height: 100px;
+  }
 }
+
 
 .paragraphs-item-p-featured {
   margin-bottom: 0;
@@ -538,21 +561,6 @@ div[class*="featured"] {
   }
 }
 
-.span6 {
-  .paragraphs-item-p-featured.has-image.has-video {
-    .field-name-field-p-featured-image,
-    .field-name-field-p-featured-video {
-      width: 100%;
-    }
-
-    .group-overlay-text {
-      background: transparent;
-      position: relative;
-      width: 100%;
-    }
-  }
-}
-
 .paragraphs-item-p-featured.has-video {
   background: #fff;
 
@@ -560,7 +568,7 @@ div[class*="featured"] {
   .field-name-field-p-featured-video {
     float: left;
     height: 400px;
-    width: 61%;
+    width: 100%;
 
     @media (max-width: 979px) {
 
@@ -611,11 +619,39 @@ div[class*="featured"] {
       }
     }
 
+    .field-name-field-p-featured-superhead a:hover {
+      text-decoration: underline;
+      color: #333333;
+    }
+
     .field-name-field-p-featured-description {
       .field-item {
         margin: 0;
       }
     }
+  }
+}
+
+.fullwidth .span6 .paragraphs-item-p-featured.has-video {
+  div.group-overlay-text {
+    float: left;
+    margin-left: 0;
+    padding: 6%;
+    position: relative;
+    text-align: center;
+    width: 88%;
+
+    @media (max-width: 979px) {
+
+      width: auto;
+    }
+  }
+
+  .field-name-field-p-featured-image,
+  .field-name-field-p-featured-video {
+    float: left;
+    height: 400px;
+    width: 100%;
   }
 }
 
@@ -683,6 +719,8 @@ div[class*="featured"] {
       @media (max-width: 580px) {
 
         font-size: 26px;
+        margin: 10px 0;
+        width: 100%;
       }
     }
 
@@ -701,14 +739,56 @@ div[class*="featured"] {
   }
 
   &.has-video {
+    background: #fff;
+
+    .field-name-field-p-featured-image,
+    .field-name-field-p-featured-video {
+      float: left;
+      height: 400px;
+      width: 61%;
+
+      @media (max-width: 979px) {
+
+        width: 100%;
+      }
+    }
+
     div.group-overlay-text {
-      margin-top: 0;
-      padding: 3% 3% 0;
+      position: absolute;
+      padding: 3% 3% 0;		       background: #fff;
+      color: #000;
+      display: block;
+      float: right;
+      height: auto;
+      margin-left: 61%;
+      padding: 4% 6% 0;
+      text-align: left;
+      top: 4%;
+      width: 27%;
+
+      @media (max-width: 979px) {
+
+        float: left;
+        margin-left: 0;
+        padding: 6%;
+        position: relative;
+        text-align: center;
+        width: 88%;
+      }
+
+      .group-headline-h2,
+      .field-name-field-p-featured-superhead {
+        color: #000;
+
+        a {
+          color: #000;
+        }
+      }
 
       .group-headline-h2 {
         font-size: 32px;
         margin: 30px 0 0;
-        width: auto;
+        width: 100%;
 
         @media (max-width: 979px) {
 

--- a/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
+++ b/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
@@ -212,8 +212,8 @@ div[class*="featured"] {
 
   @media (max-width: 767px) {
 
-    max-height: 200px;
-    min-height: 100px;
+    max-height: 300px;
+    min-height: 200px;
   }
 }
 
@@ -535,7 +535,7 @@ div[class*="featured"] {
 
     .field-name-field-p-featured-superhead {
       padding-top: 0;
-      
+
       a {
         text-decoration: underline;
         -webkit-text-decoration-color: #ffbd54;
@@ -644,15 +644,95 @@ div[class*="featured"] {
         margin: 0;
       }
     }
+
+    &.has-video {
+      background: #fff;
+
+      .field-name-field-p-featured-image,
+      .field-name-field-p-featured-video {
+        float: left;
+        height: 400px;
+        width: 61%;
+
+        @media (max-width: 979px) {
+
+          width: 100%;
+        }
+
+        @media (max-width: 767px) {
+
+          height: 300px;
+        }
+      }
+
+      div.group-overlay-text {
+        position: absolute;
+        padding: 3% 3% 0;		       background: #fff;
+        color: #000;
+        display: block;
+        float: right;
+        height: auto;
+        margin-left: 61%;
+        padding: 4% 6% 0;
+        text-align: left;
+        top: 4%;
+        width: 27%;
+
+        @media (max-width: 979px) {
+
+          float: left;
+          margin-left: 0;
+          padding: 3% 6% 6%;
+          position: relative;
+          text-align: center;
+          width: 88%;
+        }
+
+        .group-headline-h2,
+        .field-name-field-p-featured-superhead {
+          color: #000;
+
+          a {
+            color: #000;
+          }
+        }
+
+        .group-headline-h2 {
+          font-size: 32px;
+          margin: 30px 0 20px;
+          width: 100%;
+
+          @media (max-width: 979px) {
+
+            font-size: 32px;
+          }
+        }
+
+        .field-name-field-p-featured-description {
+          font-size: 22px;
+
+          @media (max-width: 979px) {
+
+            font-size: 20px;
+          }
+        }
+
+        .field-name-field-p-featured-description .field-item {
+          margin: 0;
+        }
+      }
+    }
   }
 }
 
 .fullwidth .span6 .paragraphs-item-p-featured.has-video,
-.fullwidth .span9 .paragraphs-item-p-featured.has-video {
+.fullwidth .span9 .paragraphs-item-p-featured.has-video,
+.span6 .paragraphs-item-p-featured.has-video,
+.span9 .paragraphs-item-p-featured.has-video {
   div.group-overlay-text {
     float: left;
     margin-left: 0;
-    padding: 6%;
+    padding: 4% 6% 6%;
     position: relative;
     text-align: center;
     width: auto;
@@ -663,6 +743,11 @@ div[class*="featured"] {
     float: left;
     height: 400px;
     width: 100%;
+
+    @media (max-width: 767px) {
+
+      height: 300px;
+    }
   }
 }
 
@@ -762,6 +847,11 @@ div[class*="featured"] {
 
         width: 100%;
       }
+
+      @media (max-width: 767px) {
+
+        height: 300px;
+      }
     }
 
     div.group-overlay-text {
@@ -781,7 +871,7 @@ div[class*="featured"] {
 
         float: left;
         margin-left: 0;
-        padding: 6%;
+        padding: 3% 6% 6%;
         position: relative;
         text-align: center;
         width: 88%;
@@ -798,7 +888,7 @@ div[class*="featured"] {
 
       .group-headline-h2 {
         font-size: 32px;
-        margin: 30px 0 0;
+        margin: 30px 0 20px;
         width: 100%;
 
         @media (max-width: 979px) {

--- a/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
+++ b/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
@@ -203,6 +203,19 @@ div[class*="featured"] {
   }
 }
 
+.paragraphs-item-p-featured.has-video > .content .field-name-field-p-featured-image img {
+  @media (max-width: 979px) {
+
+    max-height: 400px;
+    min-height: 200px;
+  }
+
+  @media (max-width: 767px) {
+
+    max-height: 200px;
+    min-height: 100px;
+  }
+}
 
 .paragraphs-item-p-featured {
   margin-bottom: 0;
@@ -521,6 +534,8 @@ div[class*="featured"] {
     transform: none;
 
     .field-name-field-p-featured-superhead {
+      padding-top: 0;
+      
       a {
         text-decoration: underline;
         -webkit-text-decoration-color: #ffbd54;
@@ -632,19 +647,15 @@ div[class*="featured"] {
   }
 }
 
-.fullwidth .span6 .paragraphs-item-p-featured.has-video {
+.fullwidth .span6 .paragraphs-item-p-featured.has-video,
+.fullwidth .span9 .paragraphs-item-p-featured.has-video {
   div.group-overlay-text {
     float: left;
     margin-left: 0;
     padding: 6%;
     position: relative;
     text-align: center;
-    width: 88%;
-
-    @media (max-width: 979px) {
-
-      width: auto;
-    }
+    width: auto;
   }
 
   .field-name-field-p-featured-image,

--- a/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
+++ b/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
@@ -666,8 +666,8 @@ div[class*="featured"] {
       }
 
       div.group-overlay-text {
+        background: #fff;
         position: absolute;
-        padding: 3% 3% 0;		       background: #fff;
         color: #000;
         display: block;
         float: right;

--- a/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
+++ b/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
@@ -145,7 +145,7 @@ div[class*="featured"] {
 }
 
 .front .span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured,
-.span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured{
+.span9 .paragraphs-items-field-featured-block-featured-full .paragraphs-item-p-featured {
   div.group-overlay-text {
     .field-name-field-p-featured-superhead {
       font-size: 20px;
@@ -884,8 +884,8 @@ div[class*="featured"] {
     }
 
     div.group-overlay-text {
+      background: #fff;
       position: absolute;
-      padding: 3% 3% 0;		       background: #fff;
       color: #000;
       display: block;
       float: right;

--- a/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
+++ b/modules/stanford_bean_types_featured/scss/stanford_bean_types_featured.scss
@@ -192,14 +192,14 @@ div[class*="featured"] {
 .paragraphs-item-p-featured > .content .field-name-field-p-featured-image img {
   @media (max-width: 979px) {
 
-    max-height: 250px;
+    max-height: 400px;
     min-height: 200px;
   }
 
   @media (max-width: 767px) {
 
-    max-height: 150px;
-    min-height: 100px;
+    max-height: 300px;
+    min-height: 200px;
   }
 }
 
@@ -634,9 +634,18 @@ div[class*="featured"] {
       }
     }
 
-    .field-name-field-p-featured-superhead a:hover {
-      text-decoration: underline;
-      color: #333333;
+    .field-name-field-p-featured-superhead {
+      a {
+        text-decoration: underline;
+        -webkit-text-decoration-color: #ffbd54;
+        text-decoration-color: #ffbd54;
+
+        &:hover {
+          color: #333333;
+          -webkit-text-decoration-color: #ffffff;
+          text-decoration-color: #ffffff;
+        }
+      }
     }
 
     .field-name-field-p-featured-description {
@@ -688,8 +697,23 @@ div[class*="featured"] {
           width: 88%;
         }
 
-        .group-headline-h2,
         .field-name-field-p-featured-superhead {
+          padding-top: 0;
+
+          a {
+            text-decoration: underline;
+            -webkit-text-decoration-color: #ffbd54;
+            text-decoration-color: #ffbd54;
+
+            &:hover {
+              color: #333333;
+              -webkit-text-decoration-color: #ffffff;
+              text-decoration-color: #ffffff;
+            }
+          }
+        }
+
+        .group-headline-h2 {
           color: #000;
 
           a {
@@ -701,6 +725,11 @@ div[class*="featured"] {
           font-size: 32px;
           margin: 30px 0 20px;
           width: 100%;
+          color: #000;
+
+          a {
+            color: #000;
+          }
 
           @media (max-width: 979px) {
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SOE Featured paragraph type video styling

# Needed By (Date)
- Sprint end

# Criticality
- Client is eagerly awaiting this for the release.

# Steps to Test
- checkout branch `7.x-2.x-dev-SOE-3561`
- `drush cc css-js`
- go to this page to see the style changes `catalog-patterns/blocks-and-beans/featured-content-blocks`
- make the fullwidth block on this page a video/image and add a video link if it's not already like that.
- see this page as an example for video content to copy https://eng-dev.stanford.edu/catalog-patterns/blocks-and-beans/featured-content-blocks
- make the test blocks on the homepage a video/image featured block as well and test out the changes there.
- if you switch back and forth between branches you will see the difference in the new styles.
- firefox and IE bugs are being handled here: 
https://stanfordits.atlassian.net/browse/SOE-3671 so no need to look at that in this PR.

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-3561
https://stanfordits.atlassian.net/browse/SOE-3499

## Related PRs

## More Information

## Folks to notify

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)